### PR TITLE
Add local GGUF backend plan

### DIFF
--- a/docs/plans/8.0-libollmchat-local-gguf-backend.md
+++ b/docs/plans/8.0-libollmchat-local-gguf-backend.md
@@ -1,0 +1,264 @@
+# 8.0 — libollmchat local GGUF backend
+
+**Status:** proposed
+
+**Pointer:** `.cursor/rules/CODING_STANDARDS.md` — Checklist for all plans · **Layout:** `docs/guide-to-writing-plans.md`
+
+---
+
+## Purpose
+
+- **🔷** Add a Vala-facing binding to a local inference library that is easily available on Debian and Ubuntu.
+- **🔷** The local library must load GGUF models.
+- **🔷** The local library must support text inference and embeddings.
+- **🔷** Implement this as an alternative backend for `libollmchat`.
+  - **🔷** End-user code should keep using the standard `libollmchat` API.
+  - **🔷** `libocvector` should not need a one-off local-vectorizer path.
+- **🔷** Replace vectorization so documents can be embedded without Ollama or OpenAI.
+- **🔷** Add code to download the BGE embedding model into `~/.local/share/ollmchat/models/`.
+
+---
+
+## Backend target
+
+- **🔷** The backend must use a distro-available inference library.
+- **💩** Use `llama.cpp` / `libllama` as the first target.
+  - **⏳** Debian and Ubuntu package it as `llama.cpp`, with development files in `libllama-dev`.
+  - **⏳** It supports GGUF model loading.
+  - **⏳** It supports embedding mode through the `libllama` C API.
+- **💩** Create a local VAPI for the subset of `llama.h` used by OLLMchat.
+  - **⏳** Keep the binding narrow.
+  - **⏳** Include only model load, context creation, tokenization, decode, sampling, embedding extraction, and cleanup.
+- **💩** Add a small C wrapper if direct Vala binding to structs or callbacks becomes brittle.
+  - **⏳** Prefer stable Vala-facing functions over exposing every `llama.cpp` detail.
+
+---
+
+## libollmchat API shape
+
+- **🔷** Callers keep using existing `libollmchat` APIs.
+  - **⏳** `Client.embed()` and `Client.embed_array()` return `Response.Embed`.
+  - **⏳** `Call.Embeddings.exec_embedding()` returns `Response.Embed`.
+  - **⏳** `Client.generate()` returns `Response.Generate`.
+  - **⏳** `Client.chat_execute()` continues to accept `Call.ChatBase`.
+- **💩** Add a backend discriminator to `Settings.Connection`.
+  - **⏳** Suggested values: `http` and `local-gguf`.
+  - **⏳** Existing configs default to `http`.
+  - **⏳** Local connections ignore `url` for transport.
+- **💩** Add local model settings to `Settings.Connection`.
+  - **⏳** `model_dir`, defaulting to `~/.local/share/ollmchat/models`.
+  - **⏳** `threads`, defaulting to detected CPU concurrency.
+  - **⏳** `context_length`, defaulting to the model metadata or `Call.Options.num_ctx`.
+  - **⏳** `embedding_pooling`, defaulting after BGE verification.
+- **💩** Add an internal backend interface under `libollmchat`.
+  - **⏳** `Backend.models()`.
+  - **⏳** `Backend.show_model(model_name)`.
+  - **⏳** `Backend.generate(call)`.
+  - **⏳** `Backend.embed(call)`.
+  - **⏳** Later: `Backend.chat(call)` if chat completions need full parity.
+- **💩** Route calls in `Client` / `Call.*` through the selected backend.
+  - **⏳** HTTP backend keeps the existing Soup implementation.
+  - **⏳** Local GGUF backend uses `libllama`.
+  - **⏳** Response objects stay the compatibility boundary.
+
+---
+
+## Model layout
+
+- **🔷** Download BGE into `~/.local/share/ollmchat/models/`.
+- **💩** Store GGUF weights and metadata side by side under that directory.
+  - **⏳** `~/.local/share/ollmchat/models/bge-m3/`
+    - **⏳** `model.gguf`
+    - **⏳** `manifest.json`
+    - **⏳** `sha256`
+  - **⏳** Keep existing `Response.Model.get_cache_path()` JSON cache behavior for remote model metadata.
+- **💩** Use a local model manifest rather than hardcoding one filename throughout the codebase.
+  - **⏳** Alias: `bge-m3:local`.
+  - **⏳** Family: `bge`.
+  - **⏳** Capabilities: `embedding`.
+  - **⏳** Dimension: detected from the first embedding and stored after verification.
+  - **⏳** Source URL and checksum: reviewed before implementation.
+- **💩** Treat a changed embedding model or dimension as an index invalidation event.
+  - **⏳** Existing FAISS indexes should be rebuilt when the local BGE model changes dimension.
+
+---
+
+## Vectorization cutover
+
+- **🔷** `libocvector` should use the standard `libollmchat` API for local embeddings.
+- **💩** Keep `libocvector` calling `Call.Embeddings`.
+  - **⏳** The configured `codebase_search.embed.connection` points to a local GGUF connection.
+  - **⏳** `Database.embed_dimension()` still probes by running a test embedding.
+  - **⏳** `VectorBuilder` and `DocumentationVectorBuilder` still receive `Response.Embed`.
+  - **⏳** `Search.execute()` still embeds the query through the same call path.
+- **💩** Remove Ollama-specific temp-model customization from local embedding calls.
+  - **⏳** `Response.Model.customize()` remains for HTTP / Ollama.
+  - **⏳** Local BGE uses model manifest options instead.
+- **💩** Decide normalization deliberately.
+  - **⏳** `Call.Embed` normalizes embeddings today.
+  - **⏳** `Call.Embeddings` currently does not normalize.
+  - **⏳** Local backend should match the vector index metric chosen for FAISS.
+
+---
+
+## Local inference behavior
+
+- **🔷** The backend must support loading a GGUF and running inference.
+- **🔷** The backend must support embeddings.
+- **💩** Deliver embeddings first.
+  - **⏳** This unblocks document vectorization without Ollama or OpenAI.
+  - **⏳** It is the lowest-risk path because responses map cleanly to `Response.Embed`.
+- **💩** Add non-streaming generate next.
+  - **⏳** Map `Client.generate()` / `Call.Generate` onto local decode.
+  - **⏳** Return `Response.Generate`.
+- **💩** Add chat after generate.
+  - **⏳** Start with non-streaming `Call.ChatCompletions` or `Call.Chat`.
+  - **⏳** Reuse `Response.Chat` and existing message conversion.
+  - **⏳** Tool calling remains HTTP-only until JSON/tool-call formatting is proven locally.
+- **💩** Streaming local chat is a later phase.
+  - **⏳** It needs token callbacks to emit `Call.ChatBase.stream_chunk`.
+
+---
+
+## Download and model management
+
+- **🔷** Add code to download the BGE model into `~/.local/share/ollmchat/models/`.
+- **💩** Add a local model manager in `libollmchat`.
+  - **⏳** Resolve model aliases to manifest entries.
+  - **⏳** Download missing GGUF files.
+  - **⏳** Resume or safely replace partial downloads.
+  - **⏳** Verify checksum before exposing the model.
+  - **⏳** Write manifest state after successful verification.
+- **💩** Reuse existing application data-directory conventions.
+  - **⏳** Use `Environment.get_user_data_dir()/ollmchat/models`.
+  - **⏳** Do not require Ollama model storage.
+- **💩** Expose local models through `Client.models()`.
+  - **⏳** Local `models()` returns installed local manifests.
+  - **⏳** Missing default BGE may appear as downloadable in the settings UI.
+- **💩** Wire settings UI after the backend works.
+  - **⏳** Add a connection type for local GGUF.
+  - **⏳** Show installed BGE state.
+  - **⏳** Offer a download action for the default BGE model.
+
+---
+
+## Build and packaging
+
+- **💩** Add Meson detection for `libllama`.
+  - **⏳** Prefer `dependency('llama')` when the distro exposes pkg-config.
+  - **⏳** Support Debian private pkg-config paths if needed.
+  - **⏳** Fail with a clear message when local GGUF support is enabled but headers are missing.
+- **💩** Make local GGUF support a Meson feature option.
+  - **⏳** Suggested option: `local_gguf=auto|enabled|disabled`.
+  - **⏳** `auto` builds without local support when `libllama-dev` is unavailable.
+  - **⏳** `enabled` fails if the dependency is unavailable.
+- **💩** Update Debian packaging.
+  - **⏳** Add `libllama-dev` to `Build-Depends` when local GGUF support is enabled for the package.
+  - **⏳** Add the runtime `libllama` dependency through `${shlibs:Depends}`.
+  - **⏳** Review whether `libocvector` packaging also needs FAISS/tree-sitter dependency fixes in the same packaging pass.
+
+---
+
+## Phased delivery
+
+### Phase 1 — dependency spike and VAPI
+
+- **💩** `⏳` Confirm exact Debian and Ubuntu `libllama-dev` compile/link flags.
+- **💩** `⏳` Add the narrow VAPI or wrapper target.
+- **💩** `⏳` Build a tiny local example that loads a GGUF and returns one embedding.
+
+### Phase 2 — backend abstraction in libollmchat
+
+- **💩** `⏳` Add backend selection to `Settings.Connection`.
+- **💩** `⏳` Add HTTP backend wrapper around existing behavior.
+- **💩** `⏳` Add local GGUF backend skeleton.
+- **💩** `⏳` Keep existing public API signatures unchanged.
+
+### Phase 3 — local embeddings
+
+- **🔷** `⏳` Implement local BGE embeddings without Ollama or OpenAI.
+- **💩** `⏳` Return `Response.Embed` from local calls.
+- **💩** `⏳` Preserve dimension probing.
+- **💩** `⏳` Add vector dump comparison tests for repeatability.
+
+### Phase 4 — BGE download
+
+- **🔷** `⏳` Download BGE into `~/.local/share/ollmchat/models/`.
+- **💩** `⏳` Add manifest, checksum verification, and partial-download handling.
+- **💩** `⏳` Expose install state through `Client.models()` and settings UI.
+
+### Phase 5 — libocvector cutover
+
+- **🔷** `⏳` Configure codebase/document vectorization to use the local backend.
+- **💩** `⏳` Keep `libocvector` call sites on `Call.Embeddings`.
+- **💩** `⏳` Rebuild or invalidate FAISS indexes when model identity or dimension changes.
+
+### Phase 6 — local generate and chat
+
+- **🔷** `⏳` Support local GGUF text inference through the standard API.
+- **💩** `⏳` Implement non-streaming `Client.generate()` first.
+- **💩** `⏳` Add non-streaming chat after generate.
+- **💩** `⏳` Treat streaming and tool calling as follow-up work unless explicitly promoted.
+
+---
+
+## Current code pointers
+
+- **ℹ️** `libollmchat/Client.vala`
+  - Existing public API surface for chat, generate, and embeddings.
+- **ℹ️** `libollmchat/Call/Base.vala`
+  - Existing HTTP transport path.
+- **ℹ️** `libollmchat/Call/Embeddings.vala`
+  - Current OpenAI-compatible embedding call used by `libocvector`.
+- **ℹ️** `libollmchat/Call/Embed.vala`
+  - Current Ollama-native embedding call and normalization behavior.
+- **ℹ️** `libollmchat/Response/Embed.vala`
+  - Compatibility response type for both Ollama and OpenAI embedding shapes.
+- **ℹ️** `libocvector/Database.vala`
+  - Dimension probe and direct embedding call sites.
+- **ℹ️** `libocvector/Indexing/VectorBuilder.vala`
+  - Code embedding batches.
+- **ℹ️** `libocvector/Indexing/DocumentationVectorBuilder.vala`
+  - Documentation embedding batches.
+- **ℹ️** `libocvector/Search/Search.vala`
+  - Query embedding for search.
+- **ℹ️** `libocvector/Tool/CodebaseSearchToolConfig.vala`
+  - Current default `bge-m3:latest` model usage.
+- **ℹ️** `libollmchat/Response/Model.vala`
+  - Existing model metadata cache under `~/.local/share/ollmchat/models/`.
+
+---
+
+## Open questions
+
+- **💩** Which exact BGE GGUF should be the default?
+  - **⏳** Need a reviewed source URL and checksum.
+  - **⏳** Need expected dimension and pooling mode.
+- **💩** Should the first default be `bge-m3` or a smaller BGE variant for faster CPU-only indexing?
+- **💩** Should local GGUF support be mandatory for Debian packages or optional through a separate package?
+- **💩** Should local chat use the Ollama-style `Call.Chat` surface, OpenAI-style `Call.ChatCompletions`, or both?
+- **💩** Should GPU backends be exposed in config now, or left to distro `llama.cpp` defaults?
+
+---
+
+## Concrete code proposals
+
+- **⏳** Deferred until this proposal is reviewed.
+- **💩** First implementation pass should produce mechanical edits for:
+  - **⏳** `vapi/llama.vapi` or a wrapper under `libollmchat/Local/`.
+  - **⏳** `libollmchat/Settings/Connection.vala` backend fields.
+  - **⏳** `libollmchat/Backend/*.vala` HTTP and local implementations.
+  - **⏳** `libollmchat/Client.vala` routing.
+  - **⏳** `libollmchat/Call/Embeddings.vala` local backend dispatch.
+  - **⏳** `libollmchat/meson.build` and `debian/control`.
+  - **⏳** `libocvector/Tool/CodebaseSearchToolConfig.vala` default local embedding configuration.
+
+---
+
+## LLM implementer guardrails
+
+- **🚫** Do not add a separate `libocvector`-only local embedder.
+- **🚫** Do not require Ollama or OpenAI for document embeddings after the cutover.
+- **🚫** Do not hardcode one developer's home path.
+- **🚫** Do not silently reuse FAISS indexes created with a different embedding model or dimension.
+- **🚫** Do not make streaming chat or local tool-calling a blocker for local embeddings.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add a proposed plan for a `libollmchat` local GGUF backend.
- Scope the backend around Debian/Ubuntu `llama.cpp` / `libllama` with a narrow VAPI or wrapper.
- Keep end-user and `libocvector` code on standard `libollmchat` APIs while enabling local BGE embeddings.
- Include model download/storage, packaging, vectorization cutover, phased delivery, and open questions.

## Verification

- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9834812e-4e16-4e84-9d4c-b9e1f978e8f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9834812e-4e16-4e84-9d4c-b9e1f978e8f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

