### PR TITLE
Add sqgipkg packaging and release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release
+
+# Builds Linux AppImages (x86_64 + aarch64) and the Windows installer with
+# sqgipkg, then publishes them as release assets for tags like `v1.0.0`.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  APPIMAGE_EXTRACT_AND_RUN: '1'
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout OLLMchat
+        uses: actions/checkout@v4
+        with:
+          path: OLLMchat
+
+      - name: Checkout sqgi (runtime + sqgipkg)
+        uses: actions/checkout@v4
+        with:
+          repository: supercamel/sqgi
+          path: sqgi
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake ninja-build pkg-config git file ca-certificates wget \
+            meson valac gobject-introspection \
+            libglib2.0-dev libgirepository1.0-dev libffi-dev libcairo2-dev \
+            libgee-0.8-dev libjson-glib-dev libsoup-3.0-dev libxml2-dev \
+            libsqlite3-dev libgtk-4-dev libgtksourceview-5-dev libadwaita-1-dev \
+            libtree-sitter-dev libseccomp-dev libgit2-glib-1.0-dev \
+            libopenblas-dev liblapack-dev \
+            gcc-aarch64-linux-gnu g++-aarch64-linux-gnu qemu-user-static binfmt-support \
+            mingw-w64 nsis squashfs-tools
+
+      - name: Build and install sqgi
+        run: |
+          cmake -S sqgi -B sqgi/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DSQ_ENABLE_JIT=ON
+          cmake --build sqgi/build
+          sudo cmake --install sqgi/build --prefix /usr/local
+          sudo ldconfig
+
+      - name: Build Linux x86_64 AppImage
+        working-directory: OLLMchat
+        run: sqgipkg --target appimage --appimage-arch x86_64 --sqgi-source-dir "$GITHUB_WORKSPACE/sqgi"
+
+      - name: Build Linux aarch64 AppImage
+        working-directory: OLLMchat
+        run: sqgipkg --target appimage --appimage-arch aarch64 --sqgi-source-dir "$GITHUB_WORKSPACE/sqgi"
+
+      - name: Build Windows installer
+        working-directory: OLLMchat
+        run: sqgipkg --target win-nsis --sqgi-source-dir "$GITHUB_WORKSPACE/sqgi"
+
+      - name: Collect artifacts
+        working-directory: OLLMchat
+        run: |
+          mkdir -p artifacts
+          cp dist-linux-x86_64/OLLMchat.AppImage artifacts/OLLMchat-x86_64.AppImage
+          cp dist-linux-aarch64/OLLMchat.AppImage artifacts/OLLMchat-aarch64.AppImage
+          cp dist-windows-x86_64/OLLMchat-Setup.exe artifacts/OLLMchat-Setup.exe
+          ls -lh artifacts
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ollmchat-builds
+          path: OLLMchat/artifacts/*
+
+      - name: Publish release assets
+        if: startsWith(github.ref, 'refs/tags/')
+        working-directory: OLLMchat
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" artifacts/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+          || gh release upload "$GITHUB_REF_NAME" artifacts/* \
+            --repo "$GITHUB_REPOSITORY" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 build/
+build-linux-*/
+build-windows-*/
+dist-linux-*/
+dist-windows-*/
+.sqgipkg/
 
 
 debian/auto*

--- a/liboccoder/meson.build
+++ b/liboccoder/meson.build
@@ -115,6 +115,7 @@ occoder_vapi = custom_target('occoder-vapi',
     valac_exe,
     '-C', '--debug',
     '--target-glib=auto',
+  ] + sqgi_vala_args + [
     # Put build directories FIRST so we use local VAPIs instead of installed ones
     '--vapidir', meson.current_source_dir() / '../vapi',  # Source VAPIs first (fiass.vapi, tree-sitter.vapi)
     '--vapidir', meson.current_source_dir() / '../../vapi',

--- a/libocfiles/DummyFileBuffer.vala
+++ b/libocfiles/DummyFileBuffer.vala
@@ -16,11 +16,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#if !G_OS_WIN32
-[CCode (cname = "strcasestr", cheader_filename = "string.h")]
-extern unowned string? strcasestr (string haystack, string needle);
-#endif
-
 namespace OLLMfiles
 {
 	/**
@@ -190,15 +185,6 @@ namespace OLLMfiles
 				return -1;
 			}
 			var tail = haystack.substring (start_index);
-#if !G_OS_WIN32
-			if (Posix.memchr ((void*) needle, 0x80, needle.length) == null) {
-				unowned string? hit = strcasestr (tail, needle);
-				if (hit == null) {
-					return -1;
-				}
-				return start_index + (int) tail.pointer_to_offset (hit);
-			}
-#endif
 			var i = tail.casefold ().index_of (needle.casefold ());
 			return i < 0 ? -1 : start_index + i;
 		}
@@ -519,4 +505,3 @@ namespace OLLMfiles
 		}
 	}
 }
-

--- a/libocfiles/FileAlias.vala
+++ b/libocfiles/FileAlias.vala
@@ -36,7 +36,7 @@ namespace OLLMfiles
 	 * 
 	 * == Notes ==
 	 * 
-	 * Aliases resolve symlinks completely using realpath(). Target must exist and be
+	 * Aliases resolve symlinks completely using GLib.Filename.canonicalize(). Target must exist and be
 	 * within home directory. Aliases maintain their own path (where the symlink exists)
 	 * for filesystem tracking.
 	 */
@@ -86,10 +86,9 @@ namespace OLLMfiles
 			this.parent = parent;
 			this.parent_id = parent.id;
 			
-			// Use realpath directly on this.path to completely resolve all symlinks in the chain
-			// PATH_MAX is typically 4096 on Linux systems
-			var resolved_ptr = Posix.realpath(path);
-			if (resolved_ptr == null) {
+			// Resolve aliases without relying on libc realpath(), which is not available on Windows.
+			var resolved_path = GLib.Filename.canonicalize(path);
+			if (resolved_path == null || resolved_path == "") {
 				this.points_to_id = -1;
 				return;
 			}
@@ -97,16 +96,16 @@ namespace OLLMfiles
 			// Restrict aliases to user's home directory
 			 
 			// Check if resolved path is within home directory
-			if (!resolved_ptr.has_prefix(home_dir)) {
+			if (!resolved_path.has_prefix(home_dir)) {
 				GLib.warning("FileAlias.new_from_info: Alias target '%s' is outside home directory '%s', rejecting", 
-					(string)resolved_ptr, home_dir);
+					resolved_path, home_dir);
 				this.points_to_id = -1;
 				return;
 			}
 			
-			this.target_path = resolved_ptr;
+			this.target_path = resolved_path;
 			
-			var target_info = this.get_target_info(resolved_ptr);
+			var target_info = this.get_target_info(resolved_path);
 			if (target_info == null) {
 				this.points_to_id = -1;
 				this.target_path = "";
@@ -115,10 +114,10 @@ namespace OLLMfiles
 			
 			if (target_info.get_file_type() == GLib.FileType.DIRECTORY) {
 				this.points_to = new Folder.new_from_info(
-					parent.manager, null, target_info, resolved_ptr);
+					parent.manager, null, target_info, resolved_path);
 			} else {
 				this.points_to = new File.new_from_info(
-					parent.manager, null, target_info, resolved_ptr);
+					parent.manager, null, target_info, resolved_path);
 			}
 		}
 		

--- a/libocfiles/Sandbox/BubbleWindows.vala
+++ b/libocfiles/Sandbox/BubbleWindows.vala
@@ -1,0 +1,70 @@
+/*
+ * Windows fallback for the Bubble sandbox API.
+ *
+ * The real implementation is Linux-specific: it uses bubblewrap, seccomp,
+ * Unix-domain fd passing, and gio-unix stream file descriptors. On Windows,
+ * callers already fall back to GLib.Subprocess when can_wrap() is false.
+ */
+
+namespace OLLMfiles.Sandbox
+{
+	public class Bubble
+	{
+		public Overlay overlay;
+		public bool allow_network { get; private set; }
+		public string bwrap_exe { get; private set; default = ""; }
+
+		public static bool can_wrap()
+		{
+			return false;
+		}
+
+		public Bubble(OLLMfiles.Folder? project, bool allow_network, string[] write_array) throws Error
+		{
+			this.allow_network = allow_network;
+			this.overlay = new Overlay(project);
+		}
+
+		public async string exec(string command, string working_dir = "") throws Error
+		{
+			throw new GLib.IOError.NOT_SUPPORTED("Bubble sandboxing is not available on Windows");
+		}
+
+		public string[] build_bubble_args(string command, string working_dir = "") throws Error
+		{
+			throw new GLib.IOError.NOT_SUPPORTED("Bubble sandboxing is not available on Windows");
+		}
+
+		public bool can_write(string raw_path)
+		{
+			return false;
+		}
+	}
+
+	public class RunSeccomp : GLib.Object
+	{
+		public string network { get; private set; default = ""; }
+		public string fs { get; private set; default = ""; }
+		public string skipped { get; private set; default = "seccomp is not available on Windows"; }
+
+		public RunSeccomp(Bubble sandbox_bubble)
+		{
+		}
+
+		public void wire_launcher(GLib.SubprocessLauncher launcher)
+		{
+		}
+
+		public void finish_handshake()
+		{
+		}
+
+		public void detach_sources()
+		{
+		}
+
+		public void finish_evidence_formatting()
+		{
+		}
+	}
+}

--- a/libocfiles/Sandbox/Scan.vala
+++ b/libocfiles/Sandbox/Scan.vala
@@ -453,7 +453,7 @@ namespace OLLMfiles.Sandbox
 				}
 				
 				GLib.debug("creating symlink '%s' -> '%s'", real_path, symlink_target);
-				Posix.symlink(symlink_target, real_path);
+				GLib.File.new_for_path(real_path).make_symbolic_link(symlink_target, null);
 				this.copy_permissions(overlay_path, real_path);
 			} catch (GLib.Error e) {
 				GLib.warning("Cannot create symlink from overlay to real path (%s -> %s): %s", 

--- a/libocfiles/meson.build
+++ b/libocfiles/meson.build
@@ -4,29 +4,101 @@
 # Dependencies for ocfiles library
 valac = meson.get_compiler('vala')
 cc = meson.get_compiler('c')
+is_windows = host_machine.system() == 'windows'
 # Find tree-sitter library (C library for parsing)
-tree_sitter_lib = dependency('tree-sitter', required: true)
-libseccomp_lib = cc.find_library('seccomp', required: true)
-seccomp_vapi = valac.find_library(
-  'seccomp',
-  dirs: meson.current_source_dir() / '../vapi',
-  required: true,
-)
+tree_sitter_lib = dependency('tree-sitter', required: false)
+if not tree_sitter_lib.found()
+  linux_sysroot = run_command('sh', '-c', 'printf %s "$SQGI_LINUX_SYSROOT"', check: false).stdout().strip()
+  linux_triplet = run_command('sh', '-c', 'printf %s "$SQGI_LINUX_TRIPLET"', check: false).stdout().strip()
+  windows_sysroot_prefix = run_command('sh', '-c', 'printf %s "$SQGI_WINDOWS_SYSROOT_PREFIX"', check: false).stdout().strip()
+  tree_sitter_dirs = []
+  tree_sitter_compile_args = []
+  if linux_sysroot != '' and linux_triplet != ''
+    tree_sitter_dirs += linux_sysroot / 'usr' / 'lib' / linux_triplet
+    tree_sitter_compile_args += '-I' + linux_sysroot / 'usr' / 'include'
+  endif
+  if windows_sysroot_prefix != ''
+    tree_sitter_dirs += windows_sysroot_prefix / 'lib'
+    tree_sitter_compile_args += '-I' + windows_sysroot_prefix / 'include'
+  endif
+  tree_sitter_lib = declare_dependency(
+    dependencies: [cc.find_library('tree-sitter', dirs: tree_sitter_dirs, required: true)],
+    compile_args: tree_sitter_compile_args,
+  )
+endif
 ocfiles_deps = [
   dependency('gee-0.8'),
   dependency('gio-2.0'),
-  dependency('gio-unix-2.0'),
   dependency('glib-2.0'),
   dependency('gobject-2.0'),
   dependency('gmodule-2.0'),  # GModule for dynamic library loading
   dependency('json-glib-1.0'),  # Required for ProjectMigrate (JSON parsing)
   dependency('sqlite3'),
   valac.find_library('posix'),
-  valac.find_library('linux'),
   tree_sitter_lib,  # Tree-sitter C library (required - TreeBase uses TreeSitter API)
-  seccomp_vapi,
-  libseccomp_lib,
 ]
+
+ocfiles_vapi_pkgs = [
+  '--pkg=sqlite3',
+  '--pkg=json-glib-1.0',  # Required for ProjectMigrate (JSON parsing)
+  '--pkg=gmodule-2.0',  # GModule for dynamic library loading (required for TreeBase)
+  '--pkg=tree-sitter',  # Tree-sitter via vapi (required for TreeBase)
+  '--pkg=ocsqlite',
+]
+
+ocfiles_vapi_gen_pkgs = [
+  '--pkg', 'posix',
+  '--pkg', 'sqlite3',
+  '--pkg', 'json-glib-1.0',  # Required for ProjectMigrate (JSON parsing)
+  '--pkg', 'gmodule-2.0',  # GModule for dynamic library loading (required for TreeBase)
+  '--pkg', 'tree-sitter',  # Tree-sitter via vapi (required for TreeBase)
+  '--pkg', 'ocsqlite',
+  '--pkg', 'gobject-2.0',
+  '--pkg', 'glib-2.0',
+  '--pkg', 'gio-2.0',
+  '--pkg', 'gee-0.8',
+]
+
+ocfiles_extra_sources = []
+sandbox_src = files(['Sandbox/BubbleWindows.vala'])
+if not is_windows
+  libseccomp_lib = cc.find_library('seccomp', required: false)
+  if not libseccomp_lib.found()
+    linux_sysroot = run_command('sh', '-c', 'printf %s "$SQGI_LINUX_SYSROOT"', check: false).stdout().strip()
+    linux_triplet = run_command('sh', '-c', 'printf %s "$SQGI_LINUX_TRIPLET"', check: false).stdout().strip()
+    seccomp_dirs = []
+    if linux_sysroot != '' and linux_triplet != ''
+      seccomp_dirs += linux_sysroot / 'usr' / 'lib' / linux_triplet
+    endif
+    libseccomp_lib = cc.find_library('seccomp', dirs: seccomp_dirs, required: true)
+  endif
+  seccomp_vapi = valac.find_library(
+    'seccomp',
+    dirs: meson.current_source_dir() / '../vapi',
+    required: true,
+  )
+  ocfiles_deps += [
+    dependency('gio-unix-2.0'),
+    valac.find_library('linux'),
+    seccomp_vapi,
+    libseccomp_lib,
+  ]
+  ocfiles_vapi_pkgs += [
+    '--pkg=seccomp',
+    '--pkg=linux',
+    '--pkg=gio-unix-2.0',
+  ]
+  ocfiles_vapi_gen_pkgs += [
+    '--pkg', 'seccomp',
+    '--pkg', 'linux',
+    '--pkg', 'gio-unix-2.0',
+  ]
+  ocfiles_extra_sources += files(meson.current_source_dir() / '../vapi/seccomp-fd-pass.c')
+  sandbox_src = files([
+    'Sandbox/Bubble.vala',
+    'Sandbox/RunSeccomp.vala',
+  ])
+endif
 
 ocfiles_src = files([
   'BufferProviderBase.vala',
@@ -40,8 +112,6 @@ ocfiles_src = files([
   'Folder.vala',
   'Sandbox/Scan.vala',
   'Sandbox/Overlay.vala',
-  'Sandbox/Bubble.vala',
-  'Sandbox/RunSeccomp.vala',
   'FolderFiles.vala',
   'GitProviderBase.vala',
   'ProjectFile.vala',
@@ -58,6 +128,7 @@ ocfiles_src = files([
   'Diff/Differ.vala',
   'SQT/VectorMetadata.vala',  # Vector metadata (SQL) - OLLMfiles.SQT namespace
 ])
+ocfiles_src += sandbox_src
 
 # Build rpath for libraries to find each other in build directory
 lib_build_rpath = ':'.join([
@@ -67,22 +138,14 @@ lib_build_rpath = ':'.join([
 
 ocfiles_base_lib = library('ocfiles',
   dependencies: [ocfiles_deps, ocsqlite_vapi_dep],
-  sources: ocfiles_src + files(meson.current_source_dir() / '../vapi/seccomp-fd-pass.c'),
+  sources: ocfiles_src + ocfiles_extra_sources,
   vala_header: 'ocfiles.h',
   vala_vapi: 'ocfiles-meson.vapi',  # Use different name so our custom_target can use 'ocfiles.vapi'
   build_rpath: lib_build_rpath,
   include_directories: [
     include_directories('..' / 'vapi'),
   ],
-  vala_args: [
-    '--pkg=sqlite3',
-    '--pkg=json-glib-1.0',  # Required for ProjectMigrate (JSON parsing)
-    '--pkg=gmodule-2.0',  # GModule for dynamic library loading (required for TreeBase)
-    '--pkg=tree-sitter',  # Tree-sitter via vapi (required for TreeBase)
-    '--pkg=ocsqlite',
-    '--pkg=seccomp',
-    '--pkg=linux',
-    '--pkg=gio-unix-2.0',
+  vala_args: ocfiles_vapi_pkgs + [
     # Put build directories FIRST so we use local VAPIs instead of installed ones
     '--vapidir', meson.current_build_dir() / '..' / 'libocsqlite',
     '--vapidir', meson.current_source_dir() / '../vapi',  # For tree-sitter.vapi and seccomp
@@ -105,19 +168,7 @@ ocfiles_vapi = custom_target('ocfiles-vapi',
     '--vapidir', meson.current_source_dir() / '../vapi',  # For tree-sitter.vapi
     '--vapidir', meson.current_source_dir() / '../../vapi',
     '--vapidir', '/usr/share/vala/vapi',  # System VAPI directory (last, so local takes priority)
-    '--pkg', 'posix',
-    '--pkg', 'sqlite3',
-    '--pkg', 'json-glib-1.0',  # Required for ProjectMigrate (JSON parsing)
-    '--pkg', 'gmodule-2.0',  # GModule for dynamic library loading (required for TreeBase)
-    '--pkg', 'tree-sitter',  # Tree-sitter via vapi (required for TreeBase)
-    '--pkg', 'ocsqlite',
-    '--pkg', 'gobject-2.0',
-    '--pkg', 'glib-2.0',
-    '--pkg', 'gio-2.0',
-    '--pkg', 'gee-0.8',
-    '--pkg', 'seccomp',
-    '--pkg', 'linux',
-    '--pkg', 'gio-unix-2.0',
+  ] + ocfiles_vapi_gen_pkgs + [
     '--library', 'ocfiles',
     '--header', meson.current_build_dir() / 'ocfiles.h',  # Use header from library
     '--vapi', '@OUTPUT@',
@@ -134,7 +185,7 @@ ocfiles_vapi = custom_target('ocfiles-vapi',
 ocfiles_vapi_dep = declare_dependency(
   link_args: ['-L' + meson.current_build_dir(), '-locfiles'],
   sources: [ocfiles_vapi[0]],  # Include VAPI file to ensure it's built first
-  dependencies: [ocsqlite_vapi_dep]
+  dependencies: [ocsqlite_vapi_dep, ocfiles_deps]
 )
 
 # GObject Introspection for ocfiles library

--- a/libocmcp/Client/Stdio.vala
+++ b/libocmcp/Client/Stdio.vala
@@ -75,7 +75,7 @@ namespace OLLMmcp.Client
 		public override void disconnect()
 		{
 			if (this.process != null) {
-				this.process.send_signal(Posix.Signal.TERM);
+				this.process.force_exit();
 				this.process = null;
 			}
 			this.stdout_reader = null;
@@ -164,18 +164,16 @@ namespace OLLMmcp.Client
 						+ "': stdio disabled inside sandbox; set trust_sandbox true in mcp.json"
 					);
 				}
-				string[] argv = {};
-				argv += this.config.command;
-				foreach (var a in this.config.args) {
-					argv += a;
-				}
-				return argv;
+				return this.build_direct_argv();
 			}
 			if (!OLLMfiles.Sandbox.Bubble.can_wrap()) {
-				throw new GLib.IOError.FAILED(
-					"MCP server '" + this.config.id
-					+ "': bubblewrap required for stdio MCP on host"
-				);
+				if (!this.config.trust_sandbox) {
+					throw new GLib.IOError.FAILED(
+						"MCP server '" + this.config.id
+						+ "': sandboxing is unavailable; set trust_sandbox true in mcp.json"
+					);
+				}
+				return this.build_direct_argv();
 			}
 			OLLMfiles.Folder? project = this.project_manager.active_project;
 			string[] write_array = {};
@@ -200,6 +198,16 @@ namespace OLLMmcp.Client
 				args += a;
 			}
 			return args;
+		}
+
+		private string[] build_direct_argv()
+		{
+			string[] argv = {};
+			argv += this.config.command;
+			foreach (var a in this.config.args) {
+				argv += a;
+			}
+			return argv;
 		}
 
 		private async void init() throws Error

--- a/liboctools/meson.build
+++ b/liboctools/meson.build
@@ -3,8 +3,28 @@
 
 # Dependencies for octools library
 valac = meson.get_compiler('vala')
+cc = meson.get_compiler('c')
 # Find tree-sitter library (C library for parsing)
-tree_sitter_lib = dependency('tree-sitter', required: true)
+tree_sitter_lib = dependency('tree-sitter', required: false)
+if not tree_sitter_lib.found()
+  linux_sysroot = run_command('sh', '-c', 'printf %s "$SQGI_LINUX_SYSROOT"', check: false).stdout().strip()
+  linux_triplet = run_command('sh', '-c', 'printf %s "$SQGI_LINUX_TRIPLET"', check: false).stdout().strip()
+  windows_sysroot_prefix = run_command('sh', '-c', 'printf %s "$SQGI_WINDOWS_SYSROOT_PREFIX"', check: false).stdout().strip()
+  tree_sitter_dirs = []
+  tree_sitter_compile_args = []
+  if linux_sysroot != '' and linux_triplet != ''
+    tree_sitter_dirs += linux_sysroot / 'usr' / 'lib' / linux_triplet
+    tree_sitter_compile_args += '-I' + linux_sysroot / 'usr' / 'include'
+  endif
+  if windows_sysroot_prefix != ''
+    tree_sitter_dirs += windows_sysroot_prefix / 'lib'
+    tree_sitter_compile_args += '-I' + windows_sysroot_prefix / 'include'
+  endif
+  tree_sitter_lib = declare_dependency(
+    dependencies: [cc.find_library('tree-sitter', dirs: tree_sitter_dirs, required: true)],
+    compile_args: tree_sitter_compile_args,
+  )
+endif
 octools_deps = [
   dependency('gee-0.8'),
   dependency('gio-2.0'),
@@ -131,7 +151,7 @@ octools_vapi = custom_target('octools-vapi',
 octools_vapi_dep = declare_dependency(
   link_args: ['-L' + meson.current_build_dir(), '-loctools'],
   sources: [octools_vapi[0]],  # Include VAPI file to ensure it's built first
-  dependencies: [ollmchat_vapi_dep, ocfiles_vapi_dep, ocmarkdown_vapi_dep]
+  dependencies: [ollmchat_vapi_dep, ocfiles_vapi_dep, ocmarkdown_vapi_dep, octools_deps]
 )
 
 # GObject Introspection for octools library

--- a/libocvector/meson.build
+++ b/libocvector/meson.build
@@ -5,18 +5,73 @@
 valac = meson.get_compiler('vala')
 cc = meson.get_compiler('c')
 
-# Find FAISS library (static library, C++ based)
-faiss_lib = cc.find_library('faiss',
-	 dirs: ['/usr/lib/x86_64-linux-gnu'], required: true)
+# Find FAISS library (C++ based)
+faiss_lib = cc.find_library('faiss', required: false)
+faiss_compile_args = []
+if not faiss_lib.found()
+  linux_sysroot = run_command('sh', '-c', 'printf %s "$SQGI_LINUX_SYSROOT"', check: false).stdout().strip()
+  linux_triplet = run_command('sh', '-c', 'printf %s "$SQGI_LINUX_TRIPLET"', check: false).stdout().strip()
+  windows_sysroot_prefix = run_command('sh', '-c', 'printf %s "$SQGI_WINDOWS_SYSROOT_PREFIX"', check: false).stdout().strip()
+  faiss_dirs = []
+  if linux_sysroot != ''
+    faiss_dirs += linux_sysroot / 'usr' / 'lib'
+    faiss_compile_args += '-I' + linux_sysroot / 'usr' / 'include'
+    if linux_triplet != ''
+      faiss_dirs += linux_sysroot / 'usr' / 'lib' / linux_triplet
+    endif
+  endif
+  if windows_sysroot_prefix != ''
+    faiss_dirs += windows_sysroot_prefix / 'lib'
+    faiss_compile_args += '-I' + windows_sysroot_prefix / 'include'
+  endif
+  faiss_lib = cc.find_library('faiss', dirs: faiss_dirs, required: true)
+endif
+faiss_dep = declare_dependency(
+  dependencies: [faiss_lib],
+  compile_args: faiss_compile_args,
+)
 cpp = meson.get_compiler('cpp')
 cpp_std_lib = cpp.find_library('stdc++', required: true)
 # FAISS uses OpenMP for parallelization
 omp_dep = dependency('openmp', required: true)
 # FAISS uses BLAS for matrix operations
-blas_dep = dependency('blas', required: true)
+blas_dep = dependency('blas', required: false)
+lapack_dep = dependency('lapack', required: false)
+if not blas_dep.found()
+  linux_sysroot = run_command('sh', '-c', 'printf %s "$SQGI_LINUX_SYSROOT"', check: false).stdout().strip()
+  linux_triplet = run_command('sh', '-c', 'printf %s "$SQGI_LINUX_TRIPLET"', check: false).stdout().strip()
+  windows_sysroot_prefix = run_command('sh', '-c', 'printf %s "$SQGI_WINDOWS_SYSROOT_PREFIX"', check: false).stdout().strip()
+  openblas_dirs = []
+  if linux_sysroot != '' and linux_triplet != ''
+    openblas_dirs += linux_sysroot / 'usr' / 'lib' / linux_triplet / 'openblas-pthread'
+  endif
+  if windows_sysroot_prefix != ''
+    openblas_dirs += windows_sysroot_prefix / 'lib'
+  endif
+  blas_dep = cc.find_library('openblas', dirs: openblas_dirs, required: true)
+endif
 # Find tree-sitter library (C library for parsing)
-# Tree-sitter provides pkg-config support
-tree_sitter_lib = dependency('tree-sitter', required: true)
+# Tree-sitter provides pkg-config support, with a sysroot fallback for sqgipkg.
+tree_sitter_lib = dependency('tree-sitter', required: false)
+if not tree_sitter_lib.found()
+  linux_sysroot = run_command('sh', '-c', 'printf %s "$SQGI_LINUX_SYSROOT"', check: false).stdout().strip()
+  linux_triplet = run_command('sh', '-c', 'printf %s "$SQGI_LINUX_TRIPLET"', check: false).stdout().strip()
+  windows_sysroot_prefix = run_command('sh', '-c', 'printf %s "$SQGI_WINDOWS_SYSROOT_PREFIX"', check: false).stdout().strip()
+  tree_sitter_dirs = []
+  tree_sitter_compile_args = []
+  if linux_sysroot != '' and linux_triplet != ''
+    tree_sitter_dirs += linux_sysroot / 'usr' / 'lib' / linux_triplet
+    tree_sitter_compile_args += '-I' + linux_sysroot / 'usr' / 'include'
+  endif
+  if windows_sysroot_prefix != ''
+    tree_sitter_dirs += windows_sysroot_prefix / 'lib'
+    tree_sitter_compile_args += '-I' + windows_sysroot_prefix / 'include'
+  endif
+  tree_sitter_lib = declare_dependency(
+    dependencies: [cc.find_library('tree-sitter', dirs: tree_sitter_dirs, required: true)],
+    compile_args: tree_sitter_compile_args,
+  )
+endif
 
 # Our minimal C wrapper for FAISS C++ API
 faiss_wrapper_src = files('faiss_c_wrapper.cpp')
@@ -32,10 +87,12 @@ ocvector_deps = [
   dependency('libsoup-3.0'),
   dependency('sqlite3'),
   valac.find_library('posix'),
-  faiss_lib,
+  faiss_dep,
   cpp_std_lib,
+  omp_dep,
+  blas_dep,
+  lapack_dep,
   tree_sitter_lib  # Tree-sitter C library (required - Tree.vala uses TreeSitter API)
-  # Note: OpenMP and BLAS added via link_args to avoid Vala package issues
 ]
 
 # Source files for OLLMvector namespace
@@ -95,7 +152,6 @@ ocvector_base_lib = library('ocvector',
   dependencies: [ocvector_deps, ocsqlite_vapi_dep, ollmchat_vapi_dep, ocfiles_vapi_dep],
   sources: ocvector_src + faiss_wrapper_src,
   link_with: [ollmchat_base_lib],  # Need to link with ollmchat_base_lib because CodebaseSearchTool extends OLLMchat.Tool.BaseTool (similar to libollmchatgtk)
-  link_args: ['-lblas', '-llapack', '-lgomp'],  # Add BLAS, LAPACK, and OpenMP directly to linker
   vala_header: 'ocvector.h',
   vala_vapi: 'ocvector-meson.vapi',  # Use different name so our custom_target can use 'ocvector.vapi'
   build_rpath: lib_build_rpath,
@@ -183,7 +239,7 @@ ocvector_vapi = custom_target('ocvector-vapi',
 ocvector_vapi_dep = declare_dependency(
   link_args: ['-L' + meson.current_build_dir(), '-locvector'],
   sources: [ocvector_vapi[0]],  # Include VAPI file to ensure it's built first
-  dependencies: [ocsqlite_vapi_dep, ollmchat_vapi_dep, ocfiles_vapi_dep]
+  dependencies: [ocsqlite_vapi_dep, ollmchat_vapi_dep, ocfiles_vapi_dep, ocvector_deps]
 )
 
 # GObject Introspection for ocvector library

--- a/libollmchat/meson.build
+++ b/libollmchat/meson.build
@@ -17,20 +17,55 @@ ollmchat_deps = [
   ollamaweb_vapi_dep,
 ]
 
-# Compile resources for prompt system
-ollmchat_resources = gnome.compile_resources(
-  'ollmchat-resources',
-  '../resources/gresources.xml',
-  source_dir: [
-	'../resources/ollmchat-agents/code-assistant',
-	'../resources',
-	'../resources/wrapped-tools',
-	'../resources/ocvector',
-	'../resources/skill-prompts',
-	'../resources/skills'
-	],
-  c_name: 'ollmchat_resources'
+resource_dirs = [
+  '../resources/ollmchat-agents/code-assistant',
+  '../resources',
+  '../resources/wrapped-tools',
+  '../resources/ocvector',
+  '../resources/skill-prompts',
+  '../resources/skills'
+]
+
+resource_source_args = []
+foreach resource_dir : resource_dirs
+  resource_source_args += ['--sourcedir', meson.current_source_dir() / resource_dir]
+endforeach
+
+# Compile resources for prompt system. Use the build-machine tool explicitly so
+# cross builds do not try to execute a target-architecture glib-compile-resources.
+glib_compile_resources = find_program('glib-compile-resources', native: true)
+ollmchat_resources_c = custom_target(
+  'ollmchat-resources_c',
+  input: '../resources/gresources.xml',
+  output: 'ollmchat-resources.c',
+  command: [
+    glib_compile_resources,
+    '@INPUT@',
+    resource_source_args,
+    '--c-name', 'ollmchat_resources',
+    '--internal',
+    '--generate-source',
+    '--target', '@OUTPUT@',
+    '--dependency-file', '@DEPFILE@'
+  ],
+  depfile: 'ollmchat-resources.c.d'
 )
+
+ollmchat_resources_h = custom_target(
+  'ollmchat-resources_h',
+  input: '../resources/gresources.xml',
+  output: 'ollmchat-resources.h',
+  command: [
+    glib_compile_resources,
+    '@INPUT@',
+    resource_source_args,
+    '--c-name', 'ollmchat_resources',
+    '--internal',
+    '--generate-header',
+    '--target', '@OUTPUT@'
+  ]
+)
+ollmchat_resources = [ollmchat_resources_c, ollmchat_resources_h]
 
 # Source files for OLLMchat namespace (needed by CodeAssistant)
 # Settings files must come first as they are used by other files

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,28 @@ add_project_arguments(['--vapidir', meson.current_source_dir() / '../vapi'], lan
 add_project_arguments(['--vapidir', meson.current_build_dir()], language: 'vala')  # Add build dir for generated VAPIs
 add_project_arguments(['--target-glib=auto'], language: 'vala')
 
+sqgi_vala_args = []
+
+linux_sysroot = run_command('sh', '-c', 'printf %s "$SQGI_LINUX_SYSROOT"', check: false).stdout().strip()
+if linux_sysroot != ''
+  sqgi_vala_args += [
+    '--vapidir', linux_sysroot / 'usr' / 'share' / 'vala' / 'vapi',
+    '--girdir', linux_sysroot / 'usr' / 'share' / 'gir-1.0',
+  ]
+endif
+
+windows_sysroot_prefix = run_command('sh', '-c', 'printf %s "$SQGI_WINDOWS_SYSROOT_PREFIX"', check: false).stdout().strip()
+if windows_sysroot_prefix != ''
+  sqgi_vala_args += [
+    '--vapidir', windows_sysroot_prefix / 'share' / 'vala' / 'vapi',
+    '--girdir', windows_sysroot_prefix / 'share' / 'gir-1.0',
+  ]
+endif
+
+if sqgi_vala_args.length() > 0
+  add_project_arguments(sqgi_vala_args, language: 'vala')
+endif
+
 # Build libraries in dependency order
 subdir('libocsqlite')      # No dependencies
 subdir('libocmarkdown')    # No dependencies
@@ -32,8 +54,15 @@ subdir('libocvector')      # Depends on libocsqlite, libollmchat, libocfiles
 subdir('liboccoder')       # Depends on libocsqlite, libocfiles, libocvector, libollmchat
 subdir('libollmchatgtk')   # Depends on libollmchat, libocmarkdown, libocmarkdowngtk, libocsqlite
 subdir('ollmapp')         # Primary application - depends on all libraries
-subdir('examples')          # Depends on all libraries
-subdir('tests')             # Test suite - depends on examples
+if get_option('examples')
+  subdir('examples')          # Depends on all libraries
+endif
+if get_option('tests')
+  if not get_option('examples')
+    error('The tests option requires examples=true')
+  endif
+  subdir('tests')             # Test suite - depends on examples
+endif
 
 # Create wrapper scripts in top-level build directory for easier access
 # These wrappers set up LD_LIBRARY_PATH and execute the real binaries from examples/
@@ -111,10 +140,13 @@ foreach exe_info : executables_info
   )
 endforeach
 
-subdir('docs')             # Depends on all source files
+if get_option('docs')
+  subdir('docs')             # Depends on all source files
+endif
 
-# Post-install script to update icon cache and desktop database
+# Post-install script to update icon cache and desktop database when the host
+# tools are available. Minimal CI/package builders may not install both.
 gnome.post_install(
-  gtk_update_icon_cache: true,
-  update_desktop_database: true
+  gtk_update_icon_cache: find_program('gtk-update-icon-cache', required: false).found(),
+  update_desktop_database: find_program('update-desktop-database', required: false).found()
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,3 @@
+option('docs', type: 'boolean', value: true, description: 'Build valadoc documentation')
+option('examples', type: 'boolean', value: true, description: 'Build example and test utility executables')
+option('tests', type: 'boolean', value: true, description: 'Configure test suite')

--- a/sqgipkg.json
+++ b/sqgipkg.json
@@ -1,0 +1,223 @@
+{
+  "name": "OLLMchat",
+  "entry": {
+    "type": "native",
+    "linux": "build-linux-x86_64/ollmapp/ollmchat",
+    "windows": "build-windows-x86_64/ollmapp/ollmchat.exe"
+  },
+  "linux": {
+    "arches": [
+      {
+        "arch": "x86_64",
+        "build_dir": "build-linux-x86_64",
+        "entry_linux": "build-linux-x86_64/ollmapp/ollmchat",
+        "deb": {
+          "download": true,
+          "packages": [
+            "libgtk-4-dev",
+            "gir1.2-gtk-4.0",
+            "libadwaita-1-dev",
+            "gir1.2-adw-1",
+            "libgtksourceview-5-dev",
+            "gir1.2-gtksource-5",
+            "libgee-0.8-dev",
+            "libglib2.0-dev",
+            "libjson-glib-dev",
+            "libsoup-3.0-dev",
+            "libxml2-dev",
+            "libsqlite3-dev",
+            "libtree-sitter-dev",
+            "libseccomp-dev",
+            "libgit2-glib-1.0-dev",
+            "libopenblas-dev",
+            "liblapack-dev",
+            "gobject-introspection",
+            "libgirepository1.0-dev"
+          ]
+        },
+        "inherit_native_projects": false,
+        "native_projects": [
+          {
+            "name": "faiss",
+            "repo": "https://github.com/facebookresearch/faiss.git",
+            "dir": ".sqgipkg/native/faiss",
+            "ref": "v1.8.0",
+            "update": true,
+            "shallow": false,
+            "build": [
+              "cmake -E rm -rf build-linux-x86_64",
+              "cmake -S . -B build-linux-x86_64 -G Ninja ${SQGI_LINUX_CMAKE_TOOLCHAIN:+-DCMAKE_TOOLCHAIN_FILE=\"$SQGI_LINUX_CMAKE_TOOLCHAIN\"} -DFAISS_ENABLE_GPU=OFF -DFAISS_ENABLE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON -DBLA_VENDOR=OpenBLAS -DBLAS_LIBRARIES=\"$SQGI_LINUX_SYSROOT/usr/lib/$SQGI_LINUX_TRIPLET/openblas-pthread/libopenblas.so\" -DLAPACK_LIBRARIES=\"$SQGI_LINUX_SYSROOT/usr/lib/$SQGI_LINUX_TRIPLET/openblas-pthread/liblapack.so;$SQGI_LINUX_SYSROOT/usr/lib/$SQGI_LINUX_TRIPLET/openblas-pthread/libblas.so\" -DCMAKE_CXX_FLAGS=\"-I$SQGI_LINUX_SYSROOT/usr/include/$SQGI_LINUX_TRIPLET/openblas-pthread\" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr",
+              "cmake --build build-linux-x86_64 --target faiss"
+            ],
+            "install": [
+              "DESTDIR=\"$SQGI_LINUX_SYSROOT\" cmake --install build-linux-x86_64 --prefix /usr"
+            ],
+            "stage": false
+          },
+          {
+            "name": "ollmchat",
+            "dir": ".",
+            "build": [
+              "PKG_CONFIG_SYSROOT_DIR=\"$SQGI_LINUX_SYSROOT\" PKG_CONFIG_LIBDIR=\"$SQGI_LINUX_SYSROOT/usr/lib/$SQGI_LINUX_TRIPLET/pkgconfig:$SQGI_LINUX_SYSROOT/usr/share/pkgconfig\" meson setup \"$SQGI_LINUX_BUILD_DIR\" --wipe --prefix /usr --buildtype=release -Ddocs=false -Dexamples=false -Dtests=false ${SQGI_LINUX_MESON_CROSS_FILE:+--cross-file \"$SQGI_LINUX_MESON_CROSS_FILE\"} || PKG_CONFIG_SYSROOT_DIR=\"$SQGI_LINUX_SYSROOT\" PKG_CONFIG_LIBDIR=\"$SQGI_LINUX_SYSROOT/usr/lib/$SQGI_LINUX_TRIPLET/pkgconfig:$SQGI_LINUX_SYSROOT/usr/share/pkgconfig\" meson setup \"$SQGI_LINUX_BUILD_DIR\" --prefix /usr --buildtype=release -Ddocs=false -Dexamples=false -Dtests=false ${SQGI_LINUX_MESON_CROSS_FILE:+--cross-file \"$SQGI_LINUX_MESON_CROSS_FILE\"}",
+              "meson compile -C \"$SQGI_LINUX_BUILD_DIR\" ./ollmapp/ollmchat:executable"
+            ],
+            "libraries": [
+              "build-linux-x86_64/libocsqlite/libocsqlite.so",
+              "build-linux-x86_64/libocmarkdown/libocmarkdown.so",
+              "build-linux-x86_64/libollamaweb/libollamaweb.so",
+              "build-linux-x86_64/libocmarkdowngtk/libocmarkdowngtk.so",
+              "build-linux-x86_64/libocfiles/libocfiles.so",
+              "build-linux-x86_64/libollmchat/libollmchat.so",
+              "build-linux-x86_64/libocmcp/libocmcp.so",
+              "build-linux-x86_64/liboctools/liboctools.so",
+              "build-linux-x86_64/libocvector/libocvector.so",
+              "build-linux-x86_64/liboccoder/liboccoder.so",
+              "build-linux-x86_64/libollmchatgtk/libollmchatgtk.so"
+            ]
+          }
+        ]
+      },
+      {
+        "arch": "aarch64",
+        "build_dir": "build-linux-aarch64",
+        "entry_linux": "build-linux-aarch64/ollmapp/ollmchat",
+        "deb": {
+          "download": true,
+          "packages": [
+            "libgtk-4-dev",
+            "gir1.2-gtk-4.0",
+            "libadwaita-1-dev",
+            "gir1.2-adw-1",
+            "libgtksourceview-5-dev",
+            "gir1.2-gtksource-5",
+            "libgee-0.8-dev",
+            "libglib2.0-dev",
+            "libjson-glib-dev",
+            "libsoup-3.0-dev",
+            "libxml2-dev",
+            "libsqlite3-dev",
+            "libtree-sitter-dev",
+            "libseccomp-dev",
+            "libgit2-glib-1.0-dev",
+            "libopenblas-dev",
+            "liblapack-dev",
+            "gobject-introspection",
+            "libgirepository1.0-dev"
+          ]
+        },
+        "inherit_native_projects": false,
+        "native_projects": [
+          {
+            "name": "faiss",
+            "repo": "https://github.com/facebookresearch/faiss.git",
+            "dir": ".sqgipkg/native/faiss",
+            "ref": "v1.8.0",
+            "update": true,
+            "shallow": false,
+            "build": [
+              "cmake -E rm -rf build-linux-aarch64",
+              "cmake -S . -B build-linux-aarch64 -G Ninja ${SQGI_LINUX_CMAKE_TOOLCHAIN:+-DCMAKE_TOOLCHAIN_FILE=\"$SQGI_LINUX_CMAKE_TOOLCHAIN\"} -DFAISS_ENABLE_GPU=OFF -DFAISS_ENABLE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON -DBLA_VENDOR=OpenBLAS -DBLAS_LIBRARIES=\"$SQGI_LINUX_SYSROOT/usr/lib/$SQGI_LINUX_TRIPLET/openblas-pthread/libopenblas.so\" -DLAPACK_LIBRARIES=\"$SQGI_LINUX_SYSROOT/usr/lib/$SQGI_LINUX_TRIPLET/openblas-pthread/liblapack.so;$SQGI_LINUX_SYSROOT/usr/lib/$SQGI_LINUX_TRIPLET/openblas-pthread/libblas.so\" -DCMAKE_CXX_FLAGS=\"-I$SQGI_LINUX_SYSROOT/usr/include/$SQGI_LINUX_TRIPLET/openblas-pthread\" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr",
+              "cmake --build build-linux-aarch64 --target faiss"
+            ],
+            "install": [
+              "DESTDIR=\"$SQGI_LINUX_SYSROOT\" cmake --install build-linux-aarch64 --prefix /usr"
+            ],
+            "stage": false
+          },
+          {
+            "name": "ollmchat",
+            "dir": ".",
+            "build": [
+              "PKG_CONFIG_SYSROOT_DIR=\"$SQGI_LINUX_SYSROOT\" PKG_CONFIG_LIBDIR=\"$SQGI_LINUX_SYSROOT/usr/lib/$SQGI_LINUX_TRIPLET/pkgconfig:$SQGI_LINUX_SYSROOT/usr/share/pkgconfig\" meson setup \"$SQGI_LINUX_BUILD_DIR\" --wipe --prefix /usr --buildtype=release -Ddocs=false -Dexamples=false -Dtests=false ${SQGI_LINUX_MESON_CROSS_FILE:+--cross-file \"$SQGI_LINUX_MESON_CROSS_FILE\"} || PKG_CONFIG_SYSROOT_DIR=\"$SQGI_LINUX_SYSROOT\" PKG_CONFIG_LIBDIR=\"$SQGI_LINUX_SYSROOT/usr/lib/$SQGI_LINUX_TRIPLET/pkgconfig:$SQGI_LINUX_SYSROOT/usr/share/pkgconfig\" meson setup \"$SQGI_LINUX_BUILD_DIR\" --prefix /usr --buildtype=release -Ddocs=false -Dexamples=false -Dtests=false ${SQGI_LINUX_MESON_CROSS_FILE:+--cross-file \"$SQGI_LINUX_MESON_CROSS_FILE\"}",
+              "meson compile -C \"$SQGI_LINUX_BUILD_DIR\" ./ollmapp/ollmchat:executable"
+            ],
+            "libraries": [
+              "build-linux-aarch64/libocsqlite/libocsqlite.so",
+              "build-linux-aarch64/libocmarkdown/libocmarkdown.so",
+              "build-linux-aarch64/libollamaweb/libollamaweb.so",
+              "build-linux-aarch64/libocmarkdowngtk/libocmarkdowngtk.so",
+              "build-linux-aarch64/libocfiles/libocfiles.so",
+              "build-linux-aarch64/libollmchat/libollmchat.so",
+              "build-linux-aarch64/libocmcp/libocmcp.so",
+              "build-linux-aarch64/liboctools/liboctools.so",
+              "build-linux-aarch64/libocvector/libocvector.so",
+              "build-linux-aarch64/liboccoder/liboccoder.so",
+              "build-linux-aarch64/libollmchatgtk/libollmchatgtk.so"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "windows": {
+    "msys2_prefix": "mingw64",
+    "gdk_backend": "win32",
+    "build_dir": "build-windows-x86_64",
+    "packages": [
+      "mingw-w64-x86_64-vala",
+      "mingw-w64-x86_64-gcc-libs",
+      "mingw-w64-x86_64-gcc-libgfortran",
+      "mingw-w64-x86_64-libwinpthread",
+      "mingw-w64-x86_64-cmake",
+      "mingw-w64-x86_64-ninja",
+      "mingw-w64-x86_64-pkgconf",
+      "mingw-w64-x86_64-gtk4",
+      "mingw-w64-x86_64-libadwaita",
+      "mingw-w64-x86_64-gtksourceview5",
+      "mingw-w64-x86_64-libgee",
+      "mingw-w64-x86_64-json-glib",
+      "mingw-w64-x86_64-libsoup3",
+      "mingw-w64-x86_64-libxml2",
+      "mingw-w64-x86_64-sqlite3",
+      "mingw-w64-x86_64-tree-sitter",
+      "mingw-w64-x86_64-libtree-sitter",
+      "mingw-w64-x86_64-libgit2-glib",
+      "mingw-w64-x86_64-openblas"
+    ],
+    "native_dependencies": [
+      {
+        "name": "faiss",
+        "repo": "https://github.com/facebookresearch/faiss.git",
+        "dir": ".sqgipkg/native/faiss",
+        "ref": "v1.8.0",
+        "update": true,
+        "shallow": false,
+        "build": [
+          "cmake -E rm -rf build-windows-x86_64",
+          "grep -q 'MinGW aligned allocation shim' faiss/impl/platform_macros.h || perl -0pi -e 's/#include <cstdio>/#include <cstdio>\\n#if defined(_WIN32) \\&\\& !defined(_MSC_VER)\\n\\/\\/ MinGW aligned allocation shim.\\n#include <cerrno>\\n#include <malloc.h>\\n#define posix_memalign(p, a, s) (((*(p)) = _aligned_malloc((s), (a))), *(p) ? 0 : errno)\\n#define posix_memalign_free _aligned_free\\n#endif/' faiss/impl/platform_macros.h",
+          "perl -0pi -e 's/#define posix_memalign_free free/#ifndef posix_memalign_free\\n#define posix_memalign_free free\\n#endif/' faiss/impl/platform_macros.h",
+          "perl -0pi -e 's/#ifndef _MSC_VER/#ifndef _WIN32/g; s/#endif \\/\\/ !_MSC_VER/#endif \\/\\/ !_WIN32/g' faiss/invlists/InvertedListsIOHook.cpp",
+          "cmake -S . -B build-windows-x86_64 -G Ninja -DCMAKE_TOOLCHAIN_FILE=\"$SQGI_WIN_CMAKE_TOOLCHAIN\" -DFAISS_ENABLE_GPU=OFF -DFAISS_ENABLE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON -DBLA_VENDOR=OpenBLAS -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=\"$SQGI_WINDOWS_PREFIX\"",
+          "cmake --build build-windows-x86_64 --target faiss"
+        ],
+        "install": [
+          "DESTDIR=\"$SQGI_WINDOWS_SYSROOT\" cmake --install build-windows-x86_64 --prefix \"$SQGI_WINDOWS_PREFIX\""
+        ],
+        "stage": false
+      }
+    ],
+    "native_projects": [
+      {
+        "name": "ollmchat",
+        "dir": ".",
+        "build": [
+          "meson setup \"$SQGI_WINDOWS_BUILD_DIR\" --wipe --prefix \"$SQGI_WINDOWS_PREFIX\" --buildtype=release -Ddocs=false -Dexamples=false -Dtests=false --cross-file \"$SQGI_MESON_CROSS_FILE\" || meson setup \"$SQGI_WINDOWS_BUILD_DIR\" --prefix \"$SQGI_WINDOWS_PREFIX\" --buildtype=release -Ddocs=false -Dexamples=false -Dtests=false --cross-file \"$SQGI_MESON_CROSS_FILE\"",
+          "meson compile -C \"$SQGI_WINDOWS_BUILD_DIR\" ./ollmapp/ollmchat:executable"
+        ],
+        "libraries": [
+          "build-windows-x86_64/libocsqlite/libocsqlite.dll",
+          "build-windows-x86_64/libocmarkdown/libocmarkdown.dll",
+          "build-windows-x86_64/libollamaweb/libollamaweb.dll",
+          "build-windows-x86_64/libocmarkdowngtk/libocmarkdowngtk.dll",
+          "build-windows-x86_64/libocfiles/libocfiles.dll",
+          "build-windows-x86_64/libollmchat/libollmchat.dll",
+          "build-windows-x86_64/libocmcp/libocmcp.dll",
+          "build-windows-x86_64/liboctools/liboctools.dll",
+          "build-windows-x86_64/libocvector/libocvector.dll",
+          "build-windows-x86_64/liboccoder/liboccoder.dll",
+          "build-windows-x86_64/libollmchatgtk/libollmchatgtk.dll"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This adds optional sqgipkg packaging for OLLMchat.

The idea is to make releases easier without disrupting the existing build system. Normal Meson/Linux builds should continue working as before.

With the new sqgipkg.json and GitHub Actions workflow, release tags can automatically build:

Linux x86_64 AppImage
Linux aarch64 AppImage
Windows x86_64 installer

The workflow only runs on v* tags or manual dispatch, so normal development pushes are not affected.

This PR also includes some portability cleanup required for the Windows package build.

A few POSIX-specific paths have been replaced with GLib equivalents where possible, and the Linux-only sandbox/seccomp pieces now have Windows stubs so they do not block compilation on that target.

Basically: this gives the project an optional “tag a release, get distributable builds” path.

Happy to change the shape of this if you’d prefer it done differently.