### PR TITLE
Move execution parsing into action layer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,84 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      CXX: g++
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install libfaiss-dev dependencies from Ubuntu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libblas-dev \
+            liblapack-dev \
+            libomp-dev
+
+      - name: Download and install libfaiss-dev
+        run: |
+          set -euo pipefail
+          POOL="https://deb.debian.org/debian/pool/main/f/faiss"
+          deb=$(curl -fsSL "$POOL/" \
+            | grep -oE 'href="libfaiss-dev_[^"]+_amd64\.deb"' \
+            | sed 's/^href="//;s/"$//' \
+            | sort -V \
+            | tail -n1)
+          if [ -z "${deb}" ]; then
+            echo "Could not find libfaiss-dev_*_amd64.deb under ${POOL}" >&2
+            exit 1
+          fi
+          echo "Using Debian package: ${deb}"
+          curl -fsSL "$POOL/${deb}" -o /tmp/libfaiss-dev.deb
+          sudo apt-get install -y libfaiss1 || true
+          sudo dpkg -i /tmp/libfaiss-dev.deb || sudo apt-get install -f -y
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository universe -y
+          sudo apt-get update
+          sudo apt-get install -y \
+            meson \
+            ninja-build \
+            valac \
+            valadoc \
+            libgee-0.8-dev \
+            libglib2.0-dev \
+            libgtk-4-dev \
+            libgtksourceview-5-dev \
+            libadwaita-1-dev \
+            libsoup-3.0-dev \
+            libjson-glib-dev \
+            libxml2-dev \
+            libsqlite3-dev \
+            libgit2-glib-1.0-dev \
+            gobject-introspection \
+            libgirepository1.0-dev \
+            libomp-dev \
+            libblas-dev \
+            liblapack-dev \
+            libseccomp-dev \
+            libtree-sitter-dev \
+            desktop-file-utils \
+            build-essential \
+            pkg-config
+
+      - name: Setup Meson build
+        run: meson setup build --prefix=/usr
+
+      - name: Build
+        run: ninja -C build

--- a/liboccoder/Action/Base.vala
+++ b/liboccoder/Action/Base.vala
@@ -18,73 +18,37 @@ namespace OLLMcoder.Action
  * Base for task execution runners (lifted from {@link Task.Details.run_exec} /
  * {@link Task.Details.run_post_exec}). Not wired in yet — see plan 7.16.1.
  */
-public abstract class Base
+public abstract class Base : OLLMchat.Agent.Base
 {
 	protected Task.Details task;
 
 	protected Base (Task.Details task)
 	{
+		base (task.runner.sr_factory, task.session);
 		this.task = task;
+		this.replace_chat (task.chat ());
 	}
 
 	public abstract async void run () throws GLib.Error;
 
-	/**
-	 * Parse one executor response into an execution run.
-	 *
-	 * Shared by live/replay callers through {@link Task.ResultParser.exec_extract};
-	 * write-specific Change details handling lives in {@link WriteExec.extract_writes}.
-	 */
-	public static bool extract_exec(Task.ResultParser parser, Task.Tool ex)
+	protected override async void fill_model ()
 	{
-		if (!parser.has_heading("result-summary")) {
-			parser.add_issue("\n" + "This task's executor output must include a \"Result summary\" section (required). " +
-				"It was missing or not found in the response. " +
-				"Produce ## Result summary (what was found or produced; whether needs are met or gaps remain).");
-			return false;
+		if (!this.task.skill.header.has_key ("model")) {
+			yield base.fill_model ();
+			return;
 		}
-		ex.summary = parser.heading("result-summary");
-		ex.document = parser.parsed_document;
-		var sum_render = new Markdown.Document.Render();
-		sum_render.parse(ex.summary.to_markdown_with_content());
-		if (ex.parent.skill.tools.contains("write_file") && !WriteExec.extract_writes(parser, ex)) {
-			return false;
+		var skill_model = this.task.skill.header.get ("model").strip ();
+		if (skill_model != "" && this.connection.models.has_key (skill_model)) {
+			this.chat_call.model = skill_model;
+			return;
 		}
-		var vl_sum = new Task.ValidateLink(ex.parent.runner, ex.parent, Task.PhaseEnum.EXECUTION) {
-			writes = ex.writes,
-			document = sum_render.document
-		};
-		vl_sum.validate_all(sum_render.document.links);
-		if (vl_sum.issues != "") {
-			parser.add_issue(vl_sum.issues);
-			return false;
+		if (skill_model != "") {
+			this.task.add_message (new OLLMchat.Message ("ui", OLLMchat.Message.fenced (
+				"text.oc-frame-warning.collapsed Model unavailable",
+				"The skill requested the model \"" + skill_model +
+					 "\", but it was not available. Using your selected model instead.")));
 		}
-		foreach (var link in sum_render.document.links) {
-			if (link.path != "" || link.hash == "") {
-				continue;
-			}
-			foreach (var wc in ex.writes) {
-				if (!wc.document.headings.has_key(link.hash)) {
-					continue;
-				}
-				link.up_relpath(wc.file_path.strip());
-				break;
-			}
-		}
-		if (sum_render.document.headings.has_key("result-summary")) {
-			ex.summary = sum_render.document.headings.get("result-summary");
-		}
-		/* Full executor tree stays in parser.parsed_document (Path 2 still uses parsed_document.to_markdown()).
-		   ex.document still aliases parser.parsed_document until Tool.run replaces ex.document with a new summary-only Document (§5.7a). */
-		if (!ex.parent.skill.tools.contains("write_file") || ex.writes.size > 0) {
-			return true;
-		}
-		var md = parser.parsed_document.to_markdown().strip();
-		if (md.down().contains("**no changes needed**")) {
-			return true;
-		}
-		parser.add_issue("\nWrite executor output must include a recognizable Change details section, or Path 2 (full markdown must contain **no changes needed**).");
-		return false;
+		yield base.fill_model ();
 	}
 }
 

--- a/liboccoder/Action/Base.vala
+++ b/liboccoder/Action/Base.vala
@@ -28,6 +28,64 @@ public abstract class Base
 	}
 
 	public abstract async void run () throws GLib.Error;
+
+	/**
+	 * Parse one executor response into an execution run.
+	 *
+	 * Shared by live/replay callers through {@link Task.ResultParser.exec_extract};
+	 * write-specific Change details handling lives in {@link WriteExec.extract_writes}.
+	 */
+	public static bool extract_exec(Task.ResultParser parser, Task.Tool ex)
+	{
+		if (!parser.has_heading("result-summary")) {
+			parser.add_issue("\n" + "This task's executor output must include a \"Result summary\" section (required). " +
+				"It was missing or not found in the response. " +
+				"Produce ## Result summary (what was found or produced; whether needs are met or gaps remain).");
+			return false;
+		}
+		ex.summary = parser.heading("result-summary");
+		ex.document = parser.parsed_document;
+		var sum_render = new Markdown.Document.Render();
+		sum_render.parse(ex.summary.to_markdown_with_content());
+		if (ex.parent.skill.tools.contains("write_file") && !WriteExec.extract_writes(parser, ex)) {
+			return false;
+		}
+		var vl_sum = new Task.ValidateLink(ex.parent.runner, ex.parent, Task.PhaseEnum.EXECUTION) {
+			writes = ex.writes,
+			document = sum_render.document
+		};
+		vl_sum.validate_all(sum_render.document.links);
+		if (vl_sum.issues != "") {
+			parser.add_issue(vl_sum.issues);
+			return false;
+		}
+		foreach (var link in sum_render.document.links) {
+			if (link.path != "" || link.hash == "") {
+				continue;
+			}
+			foreach (var wc in ex.writes) {
+				if (!wc.document.headings.has_key(link.hash)) {
+					continue;
+				}
+				link.up_relpath(wc.file_path.strip());
+				break;
+			}
+		}
+		if (sum_render.document.headings.has_key("result-summary")) {
+			ex.summary = sum_render.document.headings.get("result-summary");
+		}
+		/* Full executor tree stays in parser.parsed_document (Path 2 still uses parsed_document.to_markdown()).
+		   ex.document still aliases parser.parsed_document until Tool.run replaces ex.document with a new summary-only Document (§5.7a). */
+		if (!ex.parent.skill.tools.contains("write_file") || ex.writes.size > 0) {
+			return true;
+		}
+		var md = parser.parsed_document.to_markdown().strip();
+		if (md.down().contains("**no changes needed**")) {
+			return true;
+		}
+		parser.add_issue("\nWrite executor output must include a recognizable Change details section, or Path 2 (full markdown must contain **no changes needed**).");
+		return false;
+	}
 }
 
 }

--- a/liboccoder/Action/PostExamMerge.vala
+++ b/liboccoder/Action/PostExamMerge.vala
@@ -33,21 +33,21 @@ public class PostExamMerge : Base
 	 */
 	public static void extract (Task.ResultParser parser, Task.Details task)
 	{
-		if (!parser.has_heading ("result-summary")) {
-			parser.add_issue ("\nPost-exec output must include ## Result summary.");
+		if (!parser.document.headings.has_key ("result-summary")) {
+			parser.issues += "\nPost-exec output must include ## Result summary.";
 			return;
 		}
-		task.post_summary = parser.heading ("result-summary");
-		task.out_doc = parser.parsed_document;
+		task.post_summary = parser.document.headings.get ("result-summary");
+		task.out_doc = parser.document;
 		var sum_render = new Markdown.Document.Render ();
 		sum_render.parse (task.post_summary.to_markdown_with_content ());
 		var vl_sum = new Task.ValidateLink (task.runner, task, Task.PhaseEnum.POST_EXEC) {
-			document = parser.parsed_document
+			document = parser.document
 		};
 		vl_sum.validate_all (sum_render.document.links);
 		task.issues += vl_sum.issues;
 		if (task.issues != "") {
-			parser.add_issue (task.issues);
+			parser.issues += task.issues;
 		}
 	}
 
@@ -55,8 +55,8 @@ public class PostExamMerge : Base
 	{
 		this.task.status = Task.PhaseEnum.POST_EXEC;
 		this.task.runner.progress.active_item_changed (this.task);
-		yield this.task.fill_action_model ();
-		this.task.clear_action_tools ();
+		yield this.fill_model ();
+		this.chat_call.tools.clear ();
 		var response_text = "";
 		var last_issues = "";
 		for (var try_count = 0; try_count < 5; try_count++) {
@@ -79,7 +79,7 @@ public class PostExamMerge : Base
 			this.task.add_message (new OLLMchat.Message ("ui-waiting",
 				"waiting for " + model_label + " to reply"));
 			this.task.add_message (new OLLMchat.Message ("agent-stage", "post_exec"));
-			var response = yield this.task.send_action_messages (messages, null);
+			var response = yield this.chat_call.send (messages, null);
 			response_text = response != null ? response.message.content : "";
 			/* Next stage: progress Idx / scroll target — binding post_exec overwrites the row’s
 			 * message with the synthesis response, so tree click scrolled to post_exec instead of

--- a/liboccoder/Action/PostExamMerge.vala
+++ b/liboccoder/Action/PostExamMerge.vala
@@ -56,7 +56,7 @@ public class PostExamMerge : Base
 		this.task.status = Task.PhaseEnum.POST_EXEC;
 		this.task.runner.progress.active_item_changed (this.task);
 		yield this.task.fill_action_model ();
-		this.task.chat_call.tools.clear ();
+		this.task.clear_action_tools ();
 		var response_text = "";
 		var last_issues = "";
 		for (var try_count = 0; try_count < 5; try_count++) {
@@ -79,7 +79,7 @@ public class PostExamMerge : Base
 			this.task.add_message (new OLLMchat.Message ("ui-waiting",
 				"waiting for " + model_label + " to reply"));
 			this.task.add_message (new OLLMchat.Message ("agent-stage", "post_exec"));
-			var response = yield this.task.chat_call.send (messages, null);
+			var response = yield this.task.send_action_messages (messages, null);
 			response_text = response != null ? response.message.content : "";
 			/* Next stage: progress Idx / scroll target — binding post_exec overwrites the row’s
 			 * message with the synthesis response, so tree click scrolled to post_exec instead of

--- a/liboccoder/Action/PostExamMerge.vala
+++ b/liboccoder/Action/PostExamMerge.vala
@@ -25,11 +25,37 @@ public class PostExamMerge : Base
 		base (task);
 	}
 
+	/**
+	 * Parse post-execution synthesis response into the task.
+	 *
+	 * Called directly by this action and indirectly through
+	 * {@link Task.ResultParser.exec_post_extract} for existing replay/live callers.
+	 */
+	public static void extract (Task.ResultParser parser, Task.Details task)
+	{
+		if (!parser.has_heading ("result-summary")) {
+			parser.add_issue ("\nPost-exec output must include ## Result summary.");
+			return;
+		}
+		task.post_summary = parser.heading ("result-summary");
+		task.out_doc = parser.parsed_document;
+		var sum_render = new Markdown.Document.Render ();
+		sum_render.parse (task.post_summary.to_markdown_with_content ());
+		var vl_sum = new Task.ValidateLink (task.runner, task, Task.PhaseEnum.POST_EXEC) {
+			document = parser.parsed_document
+		};
+		vl_sum.validate_all (sum_render.document.links);
+		task.issues += vl_sum.issues;
+		if (task.issues != "") {
+			parser.add_issue (task.issues);
+		}
+	}
+
 	public override async void run () throws GLib.Error
 	{
 		this.task.status = Task.PhaseEnum.POST_EXEC;
 		this.task.runner.progress.active_item_changed (this.task);
-		yield this.task.fill_model ();
+		yield this.task.fill_action_model ();
 		this.task.chat_call.tools.clear ();
 		var response_text = "";
 		var last_issues = "";
@@ -71,7 +97,7 @@ public class PostExamMerge : Base
 			// Before exec_post_extract: it copies task.issues into parser.issues after link checks.
 			this.task.issues = "";
 			var parser = new Task.ResultParser (this.task.runner, response_text);
-			parser.exec_post_extract (this.task);
+			PostExamMerge.extract (parser, this.task);
 			this.task.add_message (new OLLMchat.Message ("agent-issues", parser.issues));
 			if (parser.issues == "") {
 				this.task.runner.progress.active_item_changed (null);

--- a/liboccoder/Action/WriteExec.vala
+++ b/liboccoder/Action/WriteExec.vala
@@ -25,6 +25,42 @@ public class WriteExec : Base
 		base (task);
 	}
 
+	/**
+	 * Parse write executor Change details sections into the execution run.
+	 *
+	 * Called by {@link Base.extract_exec}; Result summary and link validation
+	 * remain in the shared executor parser.
+	 */
+	public static bool extract_writes (Task.ResultParser parser, Task.Tool ex)
+	{
+		ex.writes.clear ();
+		foreach (var slug in parser.header_list ()) {
+			if (slug == "result-summary") {
+				continue;
+			}
+			var hb = parser.heading (slug);
+			if (hb.parent != parser.parsed_document) {
+				continue;
+			}
+			if (!slug.has_prefix ("change-details")) {
+				parser.add_issue ("\nWrite executor: unexpected top-level section (use ## Change details or Path 2 only): \"" + slug + "\".");
+				continue;
+			}
+			var wc = new Task.WriteChange.from_header (hb, ex.parent.runner.sr_factory.project_manager);
+			if (wc.issues != "") {
+				parser.add_issue ("\n"
+					+ "Change details — " + hb.text_content ().strip () + ":"
+					+ wc.issues.strip ());
+				continue;
+			}
+			ex.writes.add (wc);
+			if (wc.output_mode.strip ().down () == "next_section") {
+				break;
+			}
+		}
+		return parser.issues == "";
+	}
+
 	public override async void run () throws GLib.Error
 	{
 		this.task.status = Task.PhaseEnum.TOOLS_RUNNING;

--- a/liboccoder/Action/WriteExec.vala
+++ b/liboccoder/Action/WriteExec.vala
@@ -26,31 +26,41 @@ public class WriteExec : Base
 	}
 
 	/**
-	 * Parse write executor Change details sections into the execution run.
+	 * Parse a write executor response into the execution run.
 	 *
-	 * Called by {@link Base.extract_exec}; Result summary and link validation
-	 * remain in the shared executor parser.
+	 * Called by {@link Task.ResultParser.exec_extract} when the skill uses
+	 * {{{ write_file }}}.
 	 */
-	public static bool extract_writes (Task.ResultParser parser, Task.Tool ex)
+	public static bool extract (Task.ResultParser parser, Task.Tool ex)
 	{
+		if (!parser.document.headings.has_key ("result-summary")) {
+			parser.issues += "\n" + "This task's executor output must include a \"Result summary\" section (required). " +
+				"It was missing or not found in the response. " +
+				"Produce ## Result summary (what was found or produced; whether needs are met or gaps remain).";
+			return false;
+		}
+		ex.summary = parser.document.headings.get ("result-summary");
+		ex.document = parser.document;
+		var sum_render = new Markdown.Document.Render ();
+		sum_render.parse (ex.summary.to_markdown_with_content ());
 		ex.writes.clear ();
-		foreach (var slug in parser.header_list ()) {
+		foreach (var slug in parser.document.header_list) {
 			if (slug == "result-summary") {
 				continue;
 			}
-			var hb = parser.heading (slug);
-			if (hb.parent != parser.parsed_document) {
+			var hb = parser.document.headings.get (slug);
+			if (hb.parent != parser.document) {
 				continue;
 			}
 			if (!slug.has_prefix ("change-details")) {
-				parser.add_issue ("\nWrite executor: unexpected top-level section (use ## Change details or Path 2 only): \"" + slug + "\".");
+				parser.issues += "\nWrite executor: unexpected top-level section (use ## Change details or Path 2 only): \"" + slug + "\".";
 				continue;
 			}
 			var wc = new Task.WriteChange.from_header (hb, ex.parent.runner.sr_factory.project_manager);
 			if (wc.issues != "") {
-				parser.add_issue ("\n"
+				parser.issues += "\n"
 					+ "Change details — " + hb.text_content ().strip () + ":"
-					+ wc.issues.strip ());
+					+ wc.issues.strip ();
 				continue;
 			}
 			ex.writes.add (wc);
@@ -58,7 +68,41 @@ public class WriteExec : Base
 				break;
 			}
 		}
-		return parser.issues == "";
+		if (parser.issues != "") {
+			return false;
+		}
+		var vl_sum = new Task.ValidateLink (ex.parent.runner, ex.parent, Task.PhaseEnum.EXECUTION) {
+			writes = ex.writes,
+			document = sum_render.document
+		};
+		vl_sum.validate_all (sum_render.document.links);
+		if (vl_sum.issues != "") {
+			parser.issues += vl_sum.issues;
+			return false;
+		}
+		foreach (var link in sum_render.document.links) {
+			if (link.path != "" || link.hash == "") {
+				continue;
+			}
+			foreach (var wc in ex.writes) {
+				if (!wc.document.headings.has_key (link.hash)) {
+					continue;
+				}
+				link.up_relpath (wc.file_path.strip ());
+				break;
+			}
+		}
+		if (sum_render.document.headings.has_key ("result-summary")) {
+			ex.summary = sum_render.document.headings.get ("result-summary");
+		}
+		if (ex.writes.size > 0) {
+			return true;
+		}
+		if (parser.document.to_markdown ().strip ().down ().contains ("**no changes needed**")) {
+			return true;
+		}
+		parser.issues += "\nWrite executor output must include a recognizable Change details section, or Path 2 (full markdown must contain **no changes needed**).";
+		return false;
 	}
 
 	public override async void run () throws GLib.Error

--- a/liboccoder/Task/Details.vala
+++ b/liboccoder/Task/Details.vala
@@ -586,6 +586,15 @@ public class Details : OLLMchat.Agent.Base, ProgressItem
 	}
 
 	/**
+	 * Allow Action runners to reuse Details model selection without exposing the
+	 * protected Agent.Base override directly.
+	 */
+	public async void fill_action_model()
+	{
+		yield this.fill_model();
+	}
+
+	/**
 	 * Task as markdown for a given phase. Does not add section headings
 	 * (e.g. `## Task`); caller adds header.
 	 * COARSE: creation keys. REFINEMENT/EXECUTION: task list + `## Tool Calls` when tools exist.

--- a/liboccoder/Task/Details.vala
+++ b/liboccoder/Task/Details.vala
@@ -595,6 +595,24 @@ public class Details : OLLMchat.Agent.Base, ProgressItem
 	}
 
 	/**
+	 * Clear tool definitions before an Action sends a plain chat request.
+	 */
+	public void clear_action_tools()
+	{
+		this.chat_call.tools.clear();
+	}
+
+	/**
+	 * Send action-owned messages through this task's chat call.
+	 */
+	public async OLLMchat.Response.Chat send_action_messages(
+		Gee.ArrayList<OLLMchat.Message> messages,
+		GLib.Cancellable? cancellable = null) throws GLib.Error
+	{
+		return yield this.chat_call.send(messages, cancellable);
+	}
+
+	/**
 	 * Task as markdown for a given phase. Does not add section headings
 	 * (e.g. `## Task`); caller adds header.
 	 * COARSE: creation keys. REFINEMENT/EXECUTION: task list + `## Tool Calls` when tools exist.

--- a/liboccoder/Task/Details.vala
+++ b/liboccoder/Task/Details.vala
@@ -586,33 +586,6 @@ public class Details : OLLMchat.Agent.Base, ProgressItem
 	}
 
 	/**
-	 * Allow Action runners to reuse Details model selection without exposing the
-	 * protected Agent.Base override directly.
-	 */
-	public async void fill_action_model()
-	{
-		yield this.fill_model();
-	}
-
-	/**
-	 * Clear tool definitions before an Action sends a plain chat request.
-	 */
-	public void clear_action_tools()
-	{
-		this.chat_call.tools.clear();
-	}
-
-	/**
-	 * Send action-owned messages through this task's chat call.
-	 */
-	public async OLLMchat.Response.Chat send_action_messages(
-		Gee.ArrayList<OLLMchat.Message> messages,
-		GLib.Cancellable? cancellable = null) throws GLib.Error
-	{
-		return yield this.chat_call.send(messages, cancellable);
-	}
-
-	/**
 	 * Task as markdown for a given phase. Does not add section headings
 	 * (e.g. `## Task`); caller adds header.
 	 * COARSE: creation keys. REFINEMENT/EXECUTION: task list + `## Tool Calls` when tools exist.

--- a/liboccoder/Task/ResultParser.vala
+++ b/liboccoder/Task/ResultParser.vala
@@ -47,7 +47,9 @@ public class ResultParser : Object
 	/**
 	 * Document built in constructor; extraction methods read from this.
 	 */
-	private Markdown.Document.Document document;
+	public Markdown.Document.Document document {
+		get; private set; default = new Markdown.Document.Document();
+	}
 
 	/**
 	 * Runner used by {@link parse_task_list} to build {@link Details}. Set in constructor.
@@ -82,46 +84,6 @@ public class ResultParser : Object
 		var render = new Markdown.Document.Render();
 		render.parse(response);
 		this.document = render.document;
-	}
-
-	/**
-	 * Parsed response document. Action parsers use this so ResultParser stays
-	 * responsible only for markdown construction and shared issue state.
-	 */
-	public Markdown.Document.Document parsed_document {
-		get { return this.document; }
-	}
-
-	/**
-	 * Convenience wrapper around document.headings.has_key().
-	 */
-	public bool has_heading(string key)
-	{
-		return this.document.headings.has_key(key);
-	}
-
-	/**
-	 * Convenience wrapper around document.headings.get().
-	 */
-	public Markdown.Document.Block heading(string key)
-	{
-		return this.document.headings.get(key);
-	}
-
-	/**
-	 * Heading slugs in document order.
-	 */
-	public Gee.ArrayList<string> header_list()
-	{
-		return this.document.header_list;
-	}
-
-	/**
-	 * Append a parser issue from code that owns the stage-specific extraction.
-	 */
-	public void add_issue(string issue)
-	{
-		this.issues += issue;
 	}
 
 	/**
@@ -590,7 +552,44 @@ public class ResultParser : Object
 	 */
 	public bool exec_extract (Tool ex)
 	{
-		return OLLMcoder.Action.Base.extract_exec(this, ex);
+		if (ex.parent.skill.tools.contains ("write_file")) {
+			return OLLMcoder.Action.WriteExec.extract (this, ex);
+		}
+		if (!this.document.headings.has_key ("result-summary")) {
+			this.issues += "\n" + "This task's executor output must include a \"Result summary\" section (required). " +
+				"It was missing or not found in the response. " +
+				"Produce ## Result summary (what was found or produced; whether needs are met or gaps remain).";
+			return false;
+		}
+		ex.summary = this.document.headings.get ("result-summary");
+		ex.document = this.document;
+		var sum_render = new Markdown.Document.Render ();
+		sum_render.parse (ex.summary.to_markdown_with_content ());
+		var vl_sum = new ValidateLink (this.runner, ex.parent, PhaseEnum.EXECUTION) {
+			writes = ex.writes,
+			document = sum_render.document
+		};
+		vl_sum.validate_all (sum_render.document.links);
+		if (vl_sum.issues != "") {
+			this.issues += vl_sum.issues;
+			return false;
+		}
+		foreach (var link in sum_render.document.links) {
+			if (link.path != "" || link.hash == "") {
+				continue;
+			}
+			foreach (var wc in ex.writes) {
+				if (!wc.document.headings.has_key (link.hash)) {
+					continue;
+				}
+				link.up_relpath (wc.file_path.strip ());
+				break;
+			}
+		}
+		if (sum_render.document.headings.has_key ("result-summary")) {
+			ex.summary = sum_render.document.headings.get ("result-summary");
+		}
+		return true;
 	}
 
 	/**

--- a/liboccoder/Task/ResultParser.vala
+++ b/liboccoder/Task/ResultParser.vala
@@ -21,9 +21,9 @@ namespace OLLMcoder.Task
  * in-memory structures (List/Step/Details) and fill task properties. Validation
  * failures are accumulated in {@link issues} so the caller can retry or report.
  *
- * Constructor builds a ''Markdown.Document''; {@link parse_task_list},
- * {@link extract_refinement}, {@link extract_exec}, and {@link exec_extract} each expect specific
- * sections and populate task_list / task / issues accordingly.
+ * Constructor builds a ''Markdown.Document''; task-list and refinement parsing
+ * stays here, while execution-stage parsing is owned by the Action layer through
+ * thin compatibility wrappers.
  *
  * How it fits in the task flow:
  *
@@ -33,7 +33,7 @@ namespace OLLMcoder.Task
  *    ResultParser, ''extract_refinement(this)''; task is updated and
  *    ''result_parser.issues'' checked.
  *  * Execution: Tool.run() receives the executor response → new ResultParser,
- *    ''exec_extract(ex)''; ex.summary (heading block) and ex.document are set. Details.run_exec() builds
+ *    ''exec_extract(ex)'' delegates to Action.Base; ex.summary (heading block) and ex.document are set. Details.run_exec() builds
  *    summaries on each Tool in Details.tools(); on success Details sets ''exec_done'' (live path).
  *    ''extract_exec(Details)'' remains for legacy/test use (returns a synthetic run; caller applies it to {@link Details.tools}).
  *
@@ -82,6 +82,46 @@ public class ResultParser : Object
 		var render = new Markdown.Document.Render();
 		render.parse(response);
 		this.document = render.document;
+	}
+
+	/**
+	 * Parsed response document. Action parsers use this so ResultParser stays
+	 * responsible only for markdown construction and shared issue state.
+	 */
+	public Markdown.Document.Document parsed_document {
+		get { return this.document; }
+	}
+
+	/**
+	 * Convenience wrapper around document.headings.has_key().
+	 */
+	public bool has_heading(string key)
+	{
+		return this.document.headings.has_key(key);
+	}
+
+	/**
+	 * Convenience wrapper around document.headings.get().
+	 */
+	public Markdown.Document.Block heading(string key)
+	{
+		return this.document.headings.get(key);
+	}
+
+	/**
+	 * Heading slugs in document order.
+	 */
+	public Gee.ArrayList<string> header_list()
+	{
+		return this.document.header_list;
+	}
+
+	/**
+	 * Append a parser issue from code that owns the stage-specific extraction.
+	 */
+	public void add_issue(string issue)
+	{
+		this.issues += issue;
 	}
 
 	/**
@@ -550,81 +590,7 @@ public class ResultParser : Object
 	 */
 	public bool exec_extract (Tool ex)
 	{
-		if (!this.document.headings.has_key ("result-summary")) {
-			this.issues += "\n" + "This task's executor output must include a \"Result summary\" section (required). " +
-				"It was missing or not found in the response. " +
-				"Produce ## Result summary (what was found or produced; whether needs are met or gaps remain).";
-			return false;
-		}
-		ex.summary = this.document.headings.get ("result-summary");
-		ex.document = this.document;
-		var sum_render = new Markdown.Document.Render ();
-		sum_render.parse (ex.summary.to_markdown_with_content ());
-		if (ex.parent.skill.tools.contains ("write_file")) {
-			ex.writes.clear ();
-			foreach (var slug in this.document.header_list) {
-				if (slug == "result-summary") {
-					continue;
-				}
-				var hb = this.document.headings.get (slug);
-				if (hb.parent != this.document) {
-					continue;
-				}
-				if (!slug.has_prefix ("change-details")) {
-					this.issues += "\nWrite executor: unexpected top-level section (use ## Change details or Path 2 only): \"" + slug + "\".";
-					continue;
-				}
-				var wc = new WriteChange.from_header (hb, ex.parent.runner.sr_factory.project_manager);
-				if (wc.issues != "") {
-					this.issues += "\n"
-						+ "Change details — " + hb.text_content ().strip () + ":"
-						+ wc.issues.strip ();
-					continue;
-				}
-				ex.writes.add (wc);
-				if (wc.output_mode.strip ().down () == "next_section") {
-					break;
-				}
-			}
-			if (this.issues != "") {
-				return false;
-			}
-		}
-		var vl_sum = new ValidateLink (this.runner, ex.parent, PhaseEnum.EXECUTION) {
-			writes = ex.writes,
-			document = sum_render.document
-		};
-		vl_sum.validate_all (sum_render.document.links);
-		if (vl_sum.issues != "") {
-			this.issues += vl_sum.issues;
-			return false;
-		}
-		foreach (var link in sum_render.document.links) {
-			if (link.path != "" || link.hash == "") {
-				continue;
-			}
-			foreach (var wc in ex.writes) {
-				if (!wc.document.headings.has_key (link.hash)) {
-					continue;
-				}
-				link.up_relpath (wc.file_path.strip ());
-				break;
-			}
-		}
-		if (sum_render.document.headings.has_key ("result-summary")) {
-			ex.summary = sum_render.document.headings.get ("result-summary");
-		}
-		/* Full executor tree stays in ResultParser.this.document (Path 2 still uses this.document.to_markdown ()).
-		   ex.document still aliases this.document until Tool.run replaces ex.document with a new summary-only Document (§5.7a). */
-		if (!ex.parent.skill.tools.contains ("write_file") || ex.writes.size > 0) {
-			return true;
-		}
-		var md = this.document.to_markdown ().strip ();
-		if (md.down ().contains ("**no changes needed**")) {
-			return true;
-		}
-		this.issues += "\nWrite executor output must include a recognizable Change details section, or Path 2 (full markdown must contain **no changes needed**).";
-		return false;
+		return OLLMcoder.Action.Base.extract_exec(this, ex);
 	}
 
 	/**
@@ -636,22 +602,7 @@ public class ResultParser : Object
 	 */
 	public void exec_post_extract(Details task)
 	{
-		if (!this.document.headings.has_key("result-summary")) {
-			this.issues += "\nPost-exec output must include ## Result summary.";
-			return;
-		}
-		task.post_summary = this.document.headings.get("result-summary");
-		task.out_doc = this.document;
-		var sum_render = new Markdown.Document.Render();
-		sum_render.parse(task.post_summary.to_markdown_with_content());
-		var vl_sum = new ValidateLink (task.runner, task, PhaseEnum.POST_EXEC) {
-			document = this.document
-		};
-		vl_sum.validate_all(sum_render.document.links);
-		task.issues += vl_sum.issues;
-		if (task.issues != "") {
-			this.issues += task.issues;
-		}
+		OLLMcoder.Action.PostExamMerge.extract(this, task);
 	}
 
 	/**

--- a/liboccoder/meson.build
+++ b/liboccoder/meson.build
@@ -47,6 +47,12 @@ occoder_src = files([
   'Task/ProgressList.vala',
   'Task/ProgressView.vala',
   'Skill/Runner.vala',  # after Task/ProgressList (Runner.progress)
+  'Action/Base.vala',
+  'Action/PostExamMerge.vala',
+  'Action/ExamSequence.vala',
+  'Action/RunTools.vala',
+  'Action/RefOnly.vala',
+  'Action/WriteExec.vala',
   'Task/ResultParser.vala',  # Task: ResultParser → List, Step, Details, Tool
   'List/SortedList.vala',  # Must come before Approvals (Approvals uses SortedList)
   'Approvals.vala',

--- a/liboctools/meson.build
+++ b/liboctools/meson.build
@@ -140,14 +140,16 @@ octools_gir = gnome.generate_gir(octools_base_lib,
   nsversion: '1.0',
   identifier_prefix: 'OLLMtools',
   symbol_prefix: 'ollmtools',
-  link_with: [ollmchat_base_lib, ocfiles_base_lib],
+  link_with: [ollmchat_base_lib, ocfiles_base_lib, ocsqlite_base_lib, ocmarkdown_base_lib],
   dependencies: [],
   extra_args: [
     '--extra-library=ollmchat',
     '--extra-library=ocfiles',
+    '--extra-library=ocsqlite',
+    '--extra-library=ocmarkdown',
     '--accept-unprefixed'
   ],
-  includes: ['GObject-2.0', 'Gio-2.0', 'Json-1.0', ollmchat_gir[0], ocfiles_gir[0]],
+  includes: ['GObject-2.0', 'Gio-2.0', 'Json-1.0', ollmchat_gir[0], ocfiles_gir[0], ocsqlite_gir[0], ocmarkdown_gir[0]],
   install: true,
   fatal_warnings: false
 )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move write executor parsing into `Action.WriteExec` as the concrete write action stage.
- Move post-exec synthesis parsing into `Action.PostExamMerge` as the concrete post-exec action stage.
- Keep `ResultParser` as the existing compatibility entry point for live/replay callers without the added generic helper/accessor layer.
- Add a GitHub Actions build workflow based on the existing docs workflow dependency setup.
- Fix full-build GIR linkage for liboctools transitive local libraries.

## Cleanup
- Removed the generic helper methods previously added on `ResultParser`, `Details`, and `Action.Base`.
- `Action.Base` no longer contains parser helper logic; it only carries action runner behavior and model selection needed by action runs.

## Testing
- `CXX=g++ ninja -C build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-107def94-0aa7-4935-9829-2b4b4746e72c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-107def94-0aa7-4935-9829-2b4b4746e72c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

