### PR TITLE
Move execution parsing into action layer

### DIFF
--- a/examples/oc-test-skill-agent.vala
+++ b/examples/oc-test-skill-agent.vala
@@ -331,7 +331,7 @@ Examples:
 				string content;
 				GLib.FileUtils.get_contents(opt_test_output, out content);
 				var parser = new OLLMcoder.Task.ResultParser(this.runner, content);
-				var ex = parser.extract_exec(detail);
+				var ex = new OLLMcoder.Action.RefOnly(detail).extract_tool(parser);
 				if (parser.issues != "") {
 					this.cl.printerr("Executor parse issues: %s\n", parser.issues);
 				}

--- a/liboccoder/Action/Base.vala
+++ b/liboccoder/Action/Base.vala
@@ -18,16 +18,107 @@ namespace OLLMcoder.Action
  * Base for task execution runners (lifted from {@link Task.Details.run_exec} /
  * {@link Task.Details.run_post_exec}). Not wired in yet — see plan 7.16.1.
  */
-public abstract class Base
+public abstract class Base : OLLMchat.Agent.Base
 {
 	protected Task.Details task;
 
 	protected Base (Task.Details task)
 	{
+		base (task.runner.sr_factory, task.session);
 		this.task = task;
+		this.replace_chat (task.chat ());
 	}
 
 	public abstract async void run () throws GLib.Error;
+
+	/**
+	 * Parse a tool executor response into the execution run.
+	 *
+	 * @param parser parsed executor response and issue accumulator
+	 * @param ex execution run to fill with summary and document
+	 * @return true when the response is valid
+	 */
+	public virtual bool extract_result (Task.ResultParser parser, Task.Tool ex)
+	{
+		if (!parser.document.headings.has_key ("result-summary")) {
+			parser.issues += "\n" + "This task's executor output must include a \"Result summary\" section (required). " +
+				"It was missing or not found in the response. " +
+				"Produce ## Result summary (what was found or produced; whether needs are met or gaps remain).";
+			return false;
+		}
+		ex.summary = parser.document.headings.get ("result-summary");
+		ex.document = parser.document;
+		var sum_render = new Markdown.Document.Render ();
+		sum_render.parse (ex.summary.to_markdown_with_content ());
+		var vl_sum = new Task.ValidateLink (this.task.runner, this.task, Task.PhaseEnum.EXECUTION) {
+			writes = ex.writes,
+			document = sum_render.document
+		};
+		vl_sum.validate_all (sum_render.document.links);
+		if (vl_sum.issues != "") {
+			parser.issues += vl_sum.issues;
+			return false;
+		}
+		foreach (var link in sum_render.document.links) {
+			if (link.path != "" || link.hash == "") {
+				continue;
+			}
+			foreach (var wc in ex.writes) {
+				if (!wc.document.headings.has_key (link.hash)) {
+					continue;
+				}
+				link.up_relpath (wc.file_path.strip ());
+				break;
+			}
+		}
+		if (sum_render.document.headings.has_key ("result-summary")) {
+			ex.summary = sum_render.document.headings.get ("result-summary");
+		}
+		return true;
+	}
+
+	/**
+	 * Parse an executor response into a synthetic execution run.
+	 *
+	 * Used by legacy/test paths that do not already have a queued run.
+	 *
+	 * @param parser parsed executor response and issue accumulator
+	 * @return synthetic execution run, or null when invalid
+	 */
+	public Task.Tool? extract_tool (Task.ResultParser parser)
+	{
+		if (!parser.document.headings.has_key ("result-summary")) {
+			parser.issues += "\n" + "This task's executor output must include a \"Result summary\" section (required). " +
+				"It was missing or not found in the response. " +
+				"Produce ## Result summary (what was found or produced; whether needs are met or gaps remain).";
+			return null;
+		}
+		var ex = new Task.Tool ((OLLMchat.Agent.Factory) this.task.runner.sr_factory,
+			this.task.runner.session, this.task, "exec");
+		ex.summary = parser.document.headings.get ("result-summary");
+		ex.document = parser.document;
+		return ex;
+	}
+
+	protected override async void fill_model ()
+	{
+		if (!this.task.skill.header.has_key ("model")) {
+			yield base.fill_model ();
+			return;
+		}
+		var skill_model = this.task.skill.header.get ("model").strip ();
+		if (skill_model != "" && this.connection.models.has_key (skill_model)) {
+			this.chat_call.model = skill_model;
+			return;
+		}
+		if (skill_model != "") {
+			this.task.add_message (new OLLMchat.Message ("ui", OLLMchat.Message.fenced (
+				"text.oc-frame-warning.collapsed Model unavailable",
+				"The skill requested the model \"" + skill_model +
+					 "\", but it was not available. Using your selected model instead.")));
+		}
+		yield base.fill_model ();
+	}
 }
 
 }

--- a/liboccoder/Action/PostExamMerge.vala
+++ b/liboccoder/Action/PostExamMerge.vala
@@ -25,12 +25,37 @@ public class PostExamMerge : Base
 		base (task);
 	}
 
+	/**
+	 * Parse post-execution synthesis response into the task.
+	 *
+	 * Called directly by this action and by replay/live compatibility callers.
+	 */
+	public void extract (Task.ResultParser parser)
+	{
+		if (!parser.document.headings.has_key ("result-summary")) {
+			parser.issues += "\nPost-exec output must include ## Result summary.";
+			return;
+		}
+		this.task.post_summary = parser.document.headings.get ("result-summary");
+		this.task.out_doc = parser.document;
+		var sum_render = new Markdown.Document.Render ();
+		sum_render.parse (this.task.post_summary.to_markdown_with_content ());
+		var vl_sum = new Task.ValidateLink (this.task.runner, this.task, Task.PhaseEnum.POST_EXEC) {
+			document = parser.document
+		};
+		vl_sum.validate_all (sum_render.document.links);
+		this.task.issues += vl_sum.issues;
+		if (this.task.issues != "") {
+			parser.issues += this.task.issues;
+		}
+	}
+
 	public override async void run () throws GLib.Error
 	{
 		this.task.status = Task.PhaseEnum.POST_EXEC;
 		this.task.runner.progress.active_item_changed (this.task);
-		yield this.task.fill_model ();
-		this.task.chat_call.tools.clear ();
+		yield this.fill_model ();
+		this.chat_call.tools.clear ();
 		var response_text = "";
 		var last_issues = "";
 		for (var try_count = 0; try_count < 5; try_count++) {
@@ -53,7 +78,7 @@ public class PostExamMerge : Base
 			this.task.add_message (new OLLMchat.Message ("ui-waiting",
 				"waiting for " + model_label + " to reply"));
 			this.task.add_message (new OLLMchat.Message ("agent-stage", "post_exec"));
-			var response = yield this.task.chat_call.send (messages, null);
+			var response = yield this.chat_call.send (messages, null);
 			response_text = response != null ? response.message.content : "";
 			/* Next stage: progress Idx / scroll target — binding post_exec overwrites the row’s
 			 * message with the synthesis response, so tree click scrolled to post_exec instead of
@@ -68,10 +93,10 @@ public class PostExamMerge : Base
 			// Ensure any literal {task_link_base} in model output is replaced so links validate
 			var task_base = "task://" + this.task.slug () + ".md";
 			response_text = response_text.replace ("{task_link_base}", task_base);
-			// Before exec_post_extract: it copies task.issues into parser.issues after link checks.
+			// Before extraction: it copies task.issues into parser.issues after link checks.
 			this.task.issues = "";
 			var parser = new Task.ResultParser (this.task.runner, response_text);
-			parser.exec_post_extract (this.task);
+			this.extract (parser);
 			this.task.add_message (new OLLMchat.Message ("agent-issues", parser.issues));
 			if (parser.issues == "") {
 				this.task.runner.progress.active_item_changed (null);

--- a/liboccoder/Action/WriteExec.vala
+++ b/liboccoder/Action/WriteExec.vala
@@ -25,6 +25,85 @@ public class WriteExec : Base
 		base (task);
 	}
 
+	/**
+	 * Parse a write executor response into the execution run.
+	 *
+	 * Called when the skill uses {{{ write_file }}}.
+	 */
+	public override bool extract_result (Task.ResultParser parser, Task.Tool ex)
+	{
+		if (!parser.document.headings.has_key ("result-summary")) {
+			parser.issues += "\n" + "This task's executor output must include a \"Result summary\" section (required). " +
+				"It was missing or not found in the response. " +
+				"Produce ## Result summary (what was found or produced; whether needs are met or gaps remain).";
+			return false;
+		}
+		ex.summary = parser.document.headings.get ("result-summary");
+		ex.document = parser.document;
+		var sum_render = new Markdown.Document.Render ();
+		sum_render.parse (ex.summary.to_markdown_with_content ());
+		ex.writes.clear ();
+		foreach (var slug in parser.document.header_list) {
+			if (slug == "result-summary") {
+				continue;
+			}
+			var hb = parser.document.headings.get (slug);
+			if (hb.parent != parser.document) {
+				continue;
+			}
+			if (!slug.has_prefix ("change-details")) {
+				parser.issues += "\nWrite executor: unexpected top-level section (use ## Change details or Path 2 only): \"" + slug + "\".";
+				continue;
+			}
+			var wc = new Task.WriteChange.from_header (hb, this.task.runner.sr_factory.project_manager);
+			if (wc.issues != "") {
+				parser.issues += "\n"
+					+ "Change details — " + hb.text_content ().strip () + ":"
+					+ wc.issues.strip ();
+				continue;
+			}
+			ex.writes.add (wc);
+			if (wc.output_mode.strip ().down () == "next_section") {
+				break;
+			}
+		}
+		if (parser.issues != "") {
+			return false;
+		}
+		var vl_sum = new Task.ValidateLink (this.task.runner, this.task, Task.PhaseEnum.EXECUTION) {
+			writes = ex.writes,
+			document = sum_render.document
+		};
+		vl_sum.validate_all (sum_render.document.links);
+		if (vl_sum.issues != "") {
+			parser.issues += vl_sum.issues;
+			return false;
+		}
+		foreach (var link in sum_render.document.links) {
+			if (link.path != "" || link.hash == "") {
+				continue;
+			}
+			foreach (var wc in ex.writes) {
+				if (!wc.document.headings.has_key (link.hash)) {
+					continue;
+				}
+				link.up_relpath (wc.file_path.strip ());
+				break;
+			}
+		}
+		if (sum_render.document.headings.has_key ("result-summary")) {
+			ex.summary = sum_render.document.headings.get ("result-summary");
+		}
+		if (ex.writes.size > 0) {
+			return true;
+		}
+		if (parser.document.to_markdown ().strip ().down ().contains ("**no changes needed**")) {
+			return true;
+		}
+		parser.issues += "\nWrite executor output must include a recognizable Change details section, or Path 2 (full markdown must contain **no changes needed**).";
+		return false;
+	}
+
 	public override async void run () throws GLib.Error
 	{
 		this.task.status = Task.PhaseEnum.TOOLS_RUNNING;

--- a/liboccoder/Skill/Runner.vala
+++ b/liboccoder/Skill/Runner.vala
@@ -933,7 +933,7 @@ namespace OLLMcoder.Skill
 						"REPLAY POST EXEC hydrate slug=%s runner_in_replay=%s",
 						d_post.slug (),
 						this.in_replay.to_string ()); */
-					pp.exec_post_extract(d_post);
+					new OLLMcoder.Action.PostExamMerge(d_post).extract(pp);
 					/* GLib.debug(
 						"REPLAY POST EXEC slug=%s step=%u detail=%u tools=%u post_issues_len=%u post_issues=%s",
 						d_post.slug(),
@@ -1005,7 +1005,9 @@ namespace OLLMcoder.Skill
 						d_exec.slug (),
 						ex_run.id,
 						this.in_replay.to_string ()); */
-					var exec_extract_ok = px.exec_extract(ex_run);
+					var extract_ok = d_exec.skill.tools.contains("write_file") ?
+						new OLLMcoder.Action.WriteExec(d_exec).extract_result(px, ex_run) :
+						new OLLMcoder.Action.RefOnly(d_exec).extract_result(px, ex_run);
 					/* GLib.debug(
 						"REPLAY EXECUTION EXTRACT slug=%s tool_run=%s step=%u detail=%u tool_pos=%u content_len=%u ok=%s issues=%s",
 						d_exec.slug(),
@@ -1014,9 +1016,9 @@ namespace OLLMcoder.Skill
 						this.replay_details_pos,
 						this.replay_tool_pos,
 						m.content.length,
-						exec_extract_ok.to_string (),
+						extract_ok.to_string (),
 						px.issues); */
-					if (!exec_extract_ok) {
+					if (!extract_ok) {
 						this.progress.rebuild();
 						break;
 					}

--- a/liboccoder/Task/Details.vala
+++ b/liboccoder/Task/Details.vala
@@ -931,10 +931,10 @@ public class Details : OLLMchat.Agent.Base, ProgressItem
 			// Ensure any literal {task_link_base} in model output is replaced so links validate
 			var task_base = "task://" + this.slug() + ".md";
 			response_text = response_text.replace("{task_link_base}", task_base);
-			// Before exec_post_extract: it copies task.issues into parser.issues after link checks.
+			// Before post-exec extraction: it copies task.issues into parser.issues after link checks.
 			this.issues = "";
 			var parser = new ResultParser(this.runner, response_text);
-			parser.exec_post_extract(this);
+			new OLLMcoder.Action.PostExamMerge(this).extract(parser);
 			this.add_message(new OLLMchat.Message("agent-issues", parser.issues));
 			if (parser.issues == "") {
 				this.runner.progress.active_item_changed(null);

--- a/liboccoder/Task/PhaseEnum.vala
+++ b/liboccoder/Task/PhaseEnum.vala
@@ -34,8 +34,9 @@ namespace OLLMcoder.Task
  *    ''exec_done'') for prompts.
  *  * ''REFINE_COMPLETED'' — completed-task markdown for iteration prompts (omits certain
  *    reference sections; see {@link Details.to_markdown}).
- *  * ''EXECUTION'' / ''POST_EXEC'' — executor LLM output vs post-exec synthesis; used in
- *    {@link ResultParser.exec_extract}, {@link ResultParser.exec_post_extract}, and matching
+ *  * ''EXECUTION'' / ''POST_EXEC'' — executor LLM output vs post-exec
+ *    synthesis; used in {@link OLLMcoder.Action.Base.extract_result},
+ *    {@link OLLMcoder.Action.PostExamMerge.extract}, and matching
  *    {@link ValidateLink} behavior.
  *
  * == Replay-only and sentinel ==
@@ -86,11 +87,13 @@ public enum PhaseEnum
 	REFINE_COMPLETED,
 	/**
 	 * Executor LLM output (''Result summary'', tool calls); {@link Tool.run} and
-	 * {@link ResultParser.exec_extract}.
+	 * {@link OLLMcoder.Action.Base.extract_result}.
 	 */
 	EXECUTION,
 	/**
-	 * Post-execution synthesis ({@link ResultParser.exec_post_extract}, {@link Details.run_post_exec}).
+	 * Post-execution synthesis
+	 * ({@link OLLMcoder.Action.PostExamMerge.extract},
+	 * {@link Details.run_post_exec}).
 	 */
 	POST_EXEC,
 	/**

--- a/liboccoder/Task/ResultParser.vala
+++ b/liboccoder/Task/ResultParser.vala
@@ -21,9 +21,9 @@ namespace OLLMcoder.Task
  * in-memory structures (List/Step/Details) and fill task properties. Validation
  * failures are accumulated in {@link issues} so the caller can retry or report.
  *
- * Constructor builds a ''Markdown.Document''; {@link parse_task_list},
- * {@link extract_refinement}, {@link extract_exec}, and {@link exec_extract} each expect specific
- * sections and populate task_list / task / issues accordingly.
+ * Constructor builds a ''Markdown.Document''; task-list and refinement parsing
+ * stays here, while execution-stage parsing is owned by the Action layer through
+ * thin compatibility wrappers.
  *
  * How it fits in the task flow:
  *
@@ -33,9 +33,11 @@ namespace OLLMcoder.Task
  *    ResultParser, ''extract_refinement(this)''; task is updated and
  *    ''result_parser.issues'' checked.
  *  * Execution: Tool.run() receives the executor response → new ResultParser,
- *    ''exec_extract(ex)''; ex.summary (heading block) and ex.document are set. Details.run_exec() builds
- *    summaries on each Tool in Details.tools(); on success Details sets ''exec_done'' (live path).
- *    ''extract_exec(Details)'' remains for legacy/test use (returns a synthetic run; caller applies it to {@link Details.tools}).
+ *    the action extracts the tool result; ex.summary (heading block) and
+ *    ex.document are set. Details.run_exec() builds summaries on each Tool
+ *    in Details.tools(); on success Details sets ''exec_done'' (live path).
+ *    ''Action.Base.extract_tool(ResultParser)'' remains for legacy/test use
+ *    (returns a synthetic run; caller applies it to {@link Details.tools}).
  *
  * @see List
  * @see Step
@@ -47,7 +49,9 @@ public class ResultParser : Object
 	/**
 	 * Document built in constructor; extraction methods read from this.
 	 */
-	private Markdown.Document.Document document;
+	public Markdown.Document.Document document {
+		get; private set; default = new Markdown.Document.Document();
+	}
 
 	/**
 	 * Runner used by {@link parse_task_list} to build {@link Details}. Set in constructor.
@@ -70,7 +74,7 @@ public class ResultParser : Object
 
 	/**
 	 * Builds document from response (''Markdown.Document.Render''). Call
-	 * ''parse_task_list'', ''extract_refinement'', ''extract_exec'', or ''exec_extract'' next.
+	 * ''parse_task_list'' or ''extract_refinement'' next.
 	 *
 	 * @param runner skill runner; used by ''parse_task_list()'' to build Details and List
 	 * @param response raw LLM markdown response (planning, refinement, or executor)
@@ -541,150 +545,6 @@ public class ResultParser : Object
 		}
 	}
 
-	/**
-	 * Parse executor response into the given Tool (exec run). Called by Tool.run().
-	 * On success sets ex.summary (heading Block) and ex.document; on failure appends to issues.
-	 *
-	 * @param ex the Tool (exec run) to fill with result summary and document
-	 * @return true on success; false on missing Result summary (issues appended)
-	 */
-	public bool exec_extract (Tool ex)
-	{
-		if (!this.document.headings.has_key ("result-summary")) {
-			this.issues += "\n" + "This task's executor output must include a \"Result summary\" section (required). " +
-				"It was missing or not found in the response. " +
-				"Produce ## Result summary (what was found or produced; whether needs are met or gaps remain).";
-			return false;
-		}
-		ex.summary = this.document.headings.get ("result-summary");
-		ex.document = this.document;
-		var sum_render = new Markdown.Document.Render ();
-		sum_render.parse (ex.summary.to_markdown_with_content ());
-		if (ex.parent.skill.tools.contains ("write_file")) {
-			ex.writes.clear ();
-			foreach (var slug in this.document.header_list) {
-				if (slug == "result-summary") {
-					continue;
-				}
-				var hb = this.document.headings.get (slug);
-				if (hb.parent != this.document) {
-					continue;
-				}
-				if (!slug.has_prefix ("change-details")) {
-					this.issues += "\nWrite executor: unexpected top-level section (use ## Change details or Path 2 only): \"" + slug + "\".";
-					continue;
-				}
-				var wc = new WriteChange.from_header (hb, ex.parent.runner.sr_factory.project_manager);
-				if (wc.issues != "") {
-					this.issues += "\n"
-						+ "Change details — " + hb.text_content ().strip () + ":"
-						+ wc.issues.strip ();
-					continue;
-				}
-				ex.writes.add (wc);
-				if (wc.output_mode.strip ().down () == "next_section") {
-					break;
-				}
-			}
-			if (this.issues != "") {
-				return false;
-			}
-		}
-		var vl_sum = new ValidateLink (this.runner, ex.parent, PhaseEnum.EXECUTION) {
-			writes = ex.writes,
-			document = sum_render.document
-		};
-		vl_sum.validate_all (sum_render.document.links);
-		if (vl_sum.issues != "") {
-			this.issues += vl_sum.issues;
-			return false;
-		}
-		foreach (var link in sum_render.document.links) {
-			if (link.path != "" || link.hash == "") {
-				continue;
-			}
-			foreach (var wc in ex.writes) {
-				if (!wc.document.headings.has_key (link.hash)) {
-					continue;
-				}
-				link.up_relpath (wc.file_path.strip ());
-				break;
-			}
-		}
-		if (sum_render.document.headings.has_key ("result-summary")) {
-			ex.summary = sum_render.document.headings.get ("result-summary");
-		}
-		/* Full executor tree stays in ResultParser.this.document (Path 2 still uses this.document.to_markdown ()).
-		   ex.document still aliases this.document until Tool.run replaces ex.document with a new summary-only Document (§5.7a). */
-		if (!ex.parent.skill.tools.contains ("write_file") || ex.writes.size > 0) {
-			return true;
-		}
-		var md = this.document.to_markdown ().strip ();
-		if (md.down ().contains ("**no changes needed**")) {
-			return true;
-		}
-		this.issues += "\nWrite executor output must include a recognizable Change details section, or Path 2 (full markdown must contain **no changes needed**).";
-		return false;
-	}
-
-	/**
-	 * Parse post-exec synthesis response into the task. Called by Details.run_post_exec().
-	 * Requires ## Result summary; sets post_summary and out_doc,
-	 * then validates each link in the output document.
-	 *
-	 * @param task the task to fill with post-exec summary and document
-	 */
-	public void exec_post_extract(Details task)
-	{
-		if (!this.document.headings.has_key("result-summary")) {
-			this.issues += "\nPost-exec output must include ## Result summary.";
-			return;
-		}
-		task.post_summary = this.document.headings.get("result-summary");
-		task.out_doc = this.document;
-		var sum_render = new Markdown.Document.Render();
-		sum_render.parse(task.post_summary.to_markdown_with_content());
-		var vl_sum = new ValidateLink (task.runner, task, PhaseEnum.POST_EXEC) {
-			document = this.document
-		};
-		vl_sum.validate_all(sum_render.document.links);
-		task.issues += vl_sum.issues;
-		if (task.issues != "") {
-			this.issues += task.issues;
-		}
-	}
-
-	/**
-	 * Fills in the result summary on the task from executor response.
-	 *
-	 * Single pass: find section "Result summary" → build one synthetic exec run with that content.
-	 * If no "Result summary" section, appends to {@link issues} and returns null. Does not mutate
-	 * {@link Details.tools} or set {@link Details.exec_done}; caller applies the returned {@link Tool} when appropriate.
-	 * Used by legacy/test paths; normal execution uses exec_extract(Tool) and the execution queue.
-	 *
-	 * Content we expect (task_execution.md):
-	 * {{{
-	 * ## Result summary
-	 * (Substance + whether needs are met; gaps or follow-up in prose as needed)
-	 * }}}
-	 *
-	 * @param task the task (runner/session context for the synthetic {@link Tool})
-	 * @return the synthetic run, or null when the required section is missing
-	 */
-	public Tool? extract_exec(Details task)
-	{
-		if (!this.document.headings.has_key("result-summary")) {
-			this.issues += "\n" + "This task's executor output must include a \"Result summary\" section (required). " +
-				"It was missing or not found in the response. " +
-				"Produce ## Result summary (what was found or produced; whether needs are met or gaps remain).";
-			return null;
-		}
-		var factory = (OLLMchat.Agent.Factory) task.runner.sr_factory;
-		var ex = new Tool(factory, task.runner.session, task, "exec");
-		ex.summary = this.document.headings.get("result-summary");
-		ex.document = this.document;
-		return ex;
-	}
 }
 
 }

--- a/liboccoder/Task/Tool.vala
+++ b/liboccoder/Task/Tool.vala
@@ -28,9 +28,14 @@ namespace OLLMcoder.Task
 		public weak Details parent { get; set; }
 		/** Execution run id (e.g. "tool-0", "ref-1", "exec"). Empty for refinement-only. */
 		public string id { get; set; default = ""; }
-		/** Result summary heading block from executor (Result summary section). Set by ResultParser.exec_extract(). Never store as text — always the Block. */
+		/**
+		 * Result summary heading block from executor (Result summary section).
+		 * Set by action extraction. Never store as text — always the Block.
+		 */
 		public Markdown.Document.Block? summary { get; set; default = null; }
-		/** Executor output document. Set by ResultParser.exec_extract() on success. */
+		/**
+		 * Executor output document. Set by action extraction on success.
+		 */
 		public Markdown.Document.Document? document { get; set; default = null; }
 		/**
 		 * Shared reference links for this exec run.
@@ -114,7 +119,8 @@ namespace OLLMcoder.Task
 		/**
 		 * Write operations parsed from the write executor output.
 		 *
-		 * Filled by {@link ResultParser.exec_extract} when the skill lists ``write_file``.
+		 * Filled by {@link OLLMcoder.Action.WriteExec.extract_result} when
+		 * the skill lists {{{ write_file }}}.
 		 * Cleared at the start of each executor retry in {@link run}.
 		 * Empty for normal executor paths — {@link run} still iterates without branching.
 		 */
@@ -293,7 +299,9 @@ namespace OLLMcoder.Task
 					throw e;
 				}
 				var parser = new ResultParser(this.parent.runner, response_text);
-				var exec_ok = parser.exec_extract(this);
+				var exec_ok = this.parent.skill.tools.contains("write_file") ?
+					new OLLMcoder.Action.WriteExec(this.parent).extract_result(parser, this) :
+					new OLLMcoder.Action.RefOnly(this.parent).extract_result(parser, this);
 				/* GLib.debug(
 					"LIVE EXECUTION EXTRACT slug=%s tool_run=%s try=%u resp_len=%u ok=%s issues=%s",
 					this.parent.slug(),

--- a/liboccoder/Task/ValidateLink.vala
+++ b/liboccoder/Task/ValidateLink.vala
@@ -32,7 +32,8 @@ public class ValidateLink : GLib.Object
 
 	/**
 	 * Change-detail sections used to resolve fragment links (hash targets).
-	 * In exec_extract, assign the same list as the Tool's writes; may be empty.
+	 * In executor extraction, assign the same list as the Tool's writes;
+	 * may be empty.
 	 */
 	public Gee.ArrayList<WriteChange> writes {
 		get; set; default = new Gee.ArrayList<WriteChange> ();

--- a/liboccoder/meson.build
+++ b/liboccoder/meson.build
@@ -47,6 +47,12 @@ occoder_src = files([
   'Task/ProgressList.vala',
   'Task/ProgressView.vala',
   'Skill/Runner.vala',  # after Task/ProgressList (Runner.progress)
+  'Action/Base.vala',
+  'Action/PostExamMerge.vala',
+  'Action/ExamSequence.vala',
+  'Action/RunTools.vala',
+  'Action/RefOnly.vala',
+  'Action/WriteExec.vala',
   'Task/ResultParser.vala',  # Task: ResultParser → List, Step, Details, Tool
   'List/SortedList.vala',  # Must come before Approvals (Approvals uses SortedList)
   'Approvals.vala',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Recreate the action-parser changes on a fresh branch from latest `main`.
- Move generic queued tool executor-result extraction into `Action.Base.extract_result(...)` and inline former `ResultParser.exec_extract(...)` call sites.
- Move legacy synthetic-tool extraction into `Action.Base.extract_tool(...)`.
- Move write executor parsing into `Action.WriteExec.extract_result(...)` as the concrete write action override.
- Move post-exec synthesis parsing into `Action.PostExamMerge.extract(...)` as an instance method.
- Keep `ResultParser` responsible for markdown parsing and refinement/list parsing, without thin execution-stage wrappers.
- Remove static action extraction methods and stale `extract_exec` / `exec_extract` references.

## Testing
- `CXX=g++ ninja -C build`
- `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-107def94-0aa7-4935-9829-2b4b4746e72c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-107def94-0aa7-4935-9829-2b4b4746e72c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

