### PR TITLE
Add Just Ask summarized history plan

### DIFF
--- a/docs/plans/2.31-just-ask-summary-history.md
+++ b/docs/plans/2.31-just-ask-summary-history.md
@@ -12,13 +12,15 @@ Checklist for all plans. Plan layout and implementation workflow:
   background summarization request.
   - The user-visible assistant reply should finish normally first.
   - The UI should be free to react to completion before the summary call runs.
-- 🔷 ⏳ Store an under-250-word concise summary of the conversation.
+- 🔷 ⏳ Store an under-250-word concise summary of the conversation in the
+  session transcript.
   - The summary should be updated after each completed Just Ask turn.
   - The summary becomes the compact history sent to the model on later turns.
-- 🔷 ⏳ Use hash-style references inside the summary.
-  - User messages should be referable as `#user-N`.
-  - Assistant responses should be referable as `#agent-N`.
-  - Tool calls or tool results should be referable as `#tool-N` when available.
+- 🔷 ⏳ Use markdown links for hash-style references inside the summary.
+  - User messages should be referable as `[#user-N](#user-N)`.
+  - Assistant responses should be referable as `[#agent-N](#agent-N)`.
+  - Tool calls or tool results should be referable as `[#tool-N](#tool-N)`
+    when available.
   - The numbers are stable message/session references, not per-role sequential
     counters.
 - 🔷 ⏳ On follow-up turns, send only a system message plus the latest user
@@ -27,7 +29,7 @@ Checklist for all plans. Plan layout and implementation workflow:
   - The system message explains that more detail is available through a history
     recall tool.
 - 🔷 ⏳ Provide a history tool that can recall a specific referenced request,
-  response, or tool event by hash link.
+  response, or tool event by markdown hash link.
 - 🔷 ⏳ Display the latest summary in the standard chat UI as a collapsed or
   summary-style output.
 
@@ -43,7 +45,7 @@ Checklist for all plans. Plan layout and implementation workflow:
   `Message.tool_calls`.
 - ℹ️ Tool replies are stored as `tool` messages with `tool_call_id` and `name`.
 - ℹ️ Session JSON currently persists top-level metadata and the full
-  `messages` array. There is no top-level conversation summary field.
+  `messages` array. There is no summary message role yet.
 
 ## Proposed behaviour
 
@@ -52,11 +54,12 @@ Checklist for all plans. Plan layout and implementation workflow:
   - After the assistant response is complete, start a non-streaming
     summarizer chat in the background.
   - The summarizer receives:
-    - the user request with its `#user-N` reference.
-    - the assistant response with its `#agent-N` reference.
+    - the user request with its `[#user-N](#user-N)` reference.
+    - the assistant response with its `[#agent-N](#agent-N)` reference.
     - any tool references from that turn.
   - The summarizer returns a concise summary under 250 words.
-  - Persist the summary and show it in the UI as the collapsed summary output.
+  - Persist the summary as a transcript message.
+  - Show that summary message in the UI as the collapsed summary output.
 - 🔷 ⏳ Later Just Ask turns:
   - Build the main request as:
     - a system message containing the stored summary and history-tool
@@ -65,24 +68,28 @@ Checklist for all plans. Plan layout and implementation workflow:
   - Do not send the full prior transcript to the main chat request.
   - After completion, send the summarizer:
     - the previous summary.
-    - the latest user request with `#user-N`.
-    - the latest assistant response with `#agent-N`.
-    - any new `#tool-N` references.
-  - Replace the stored summary with the summarizer output.
+    - the latest user request with `[#user-N](#user-N)`.
+    - the latest assistant response with `[#agent-N](#agent-N)`.
+    - any new `[#tool-N](#tool-N)` references.
+  - Append the new summary as the latest summary transcript message.
 - 🔷 ⏳ Summary references should stay useful to the model.
-  - The summary should cite important prior turns with `#user-N`,
-    `#agent-N`, and `#tool-N`.
+  - The summary should cite important prior turns with markdown links like
+    `[#user-N](#user-N)`, `[#agent-N](#agent-N)`, and
+    `[#tool-N](#tool-N)`.
   - The summary should not quote long source text or tool output.
   - If exact details are needed, the model should call the history recall tool.
 
 ## Reference model
 
+- 🔷 ⏳ Use markdown links whose `href` is a local hash anchor.
+  - `[#user-N](#user-N)` points at a persisted `user-sent` or API `user`
+    message.
+  - `[#agent-N](#agent-N)` points at persisted assistant-visible content for a
+    turn.
+  - `[#tool-N](#tool-N)` points at persisted `assistant` tool-call messages or
+    `tool` reply messages.
 - 🔷 ⏳ Use the existing persisted `session.messages` ordering as the source of
   reference numbers.
-  - `#user-N` points at a persisted `user-sent` or API `user` message.
-  - `#agent-N` points at persisted assistant-visible content for a turn.
-  - `#tool-N` points at persisted `assistant` tool-call messages or `tool`
-    reply messages.
 - 💩 ⏳ Prefer message-array indexes for `N` in the first implementation.
   - This matches the user's note that numbers are session references rather
     than sequential per role.
@@ -90,13 +97,34 @@ Checklist for all plans. Plan layout and implementation workflow:
 - 💩 ⏳ Add an explicit persisted `history_ref` on `Message` only if array
   indexes prove unstable during restore, deletion, or migration.
 
+## Summary validation
+
+- 🔷 ⏳ The summarizer input should provide a closed set of allowed markdown
+  links.
+  - The output summary may refer only to those links.
+  - Links not present in the input reference set are invalid.
+  - The allowed set includes links already present in the previous summary plus
+    links for the latest user, agent, and tool messages.
+- 🔷 ⏳ Validate the returned summary before storing it.
+  - Parse markdown links in the summary.
+  - Confirm every local hash link matches an allowed reference.
+  - Treat bare `#user-N`, `#agent-N`, or `#tool-N` text as invalid unless it is
+    part of a markdown link.
+- 🔷 ⏳ If validation fails, retry the summarizer once with the validation
+  issue.
+  - If it still fails, store no new summary message and keep the previous
+    summary as the active history context.
+- 💩 ⏳ Reuse the existing markdown parser where practical.
+  - A simple link scan is acceptable only if the markdown parser is not
+    available in `libollmchat`.
+
 ## Summary prompt contract
 
 - 🔷 ⏳ The summarizer prompt should say:
   - It receives the previous summary, the latest user request, the assistant
     response, and any tool references.
   - It must produce a concise summary under 250 words.
-  - It should cite source turns using the provided hash references.
+  - It should cite source turns using only the provided markdown links.
   - It should preserve unresolved user intent, decisions, preferences, and
     important facts.
   - It should omit filler, greetings, and raw tool output.
@@ -113,7 +141,7 @@ Checklist for all plans. Plan layout and implementation workflow:
 - 🔷 ⏳ For summarized Just Ask follow-ups, the system message should include:
   - the normal Just Ask identity or neutral assistant instruction.
   - a heading that says the conversation history is summarized.
-  - the latest stored summary.
+  - the latest `conversation-summary` transcript message.
   - instructions to call the history recall tool when a referenced turn is
     needed verbatim.
 - 🔷 ⏳ The latest user request stays the only `user` message in the request.
@@ -123,8 +151,9 @@ Checklist for all plans. Plan layout and implementation workflow:
 
 ## History recall tool
 
-- 🔷 ⏳ Add a tool that accepts one or more hash references.
-  - Examples: `#user-1`, `#agent-2`, `#tool-6`.
+- 🔷 ⏳ Add a tool that accepts one or more markdown hash references.
+  - Examples: `[#user-1](#user-1)`, `[#agent-2](#agent-2)`,
+    `[#tool-6](#tool-6)`.
   - It returns the exact stored message excerpts for those references.
 - 🔷 ⏳ The tool should work against the current session only.
   - It must not search other sessions.
@@ -139,18 +168,18 @@ Checklist for all plans. Plan layout and implementation workflow:
 
 ## Session persistence and UI
 
-- 🔷 ⏳ Persist the current summary on the session.
-  - Add a top-level session property such as `conversation_summary`.
-  - Serialize it in `History.Session.serialize_property()`.
-  - Load it through `History.SessionJson`.
+- 🔷 ⏳ Persist each generated summary in the session transcript.
+  - Add a new message role such as `conversation-summary`.
+  - Store the summary in the standard session JSON `messages` array.
+  - Treat the latest `conversation-summary` message as the active summary.
 - 🔷 ⏳ Display the latest summary as a collapsed summary output in the standard
   chat UI.
-- 💩 ⏳ Store only the latest summary as metadata.
-  - The visible UI summary message can be regenerated from metadata on restore.
-  - This avoids duplicating each summary revision in `messages`.
-- 💩 ⏳ If the UI cannot render a metadata summary without larger changes, add a
-  `ui` message for the summary as a short-term bridge.
-  - Mark it with a distinct fenced header or class so it can be collapsed later.
+- 🔷 ⏳ Do not store the active summary as a top-level session metadata field.
+  - The transcript message is the stored source of truth.
+  - Restore should find the latest summary by scanning `messages`.
+- 💩 ⏳ Mark `conversation-summary` as UI-visible and API-hidden.
+  - It should be visible through the collapsed summary UI.
+  - It should not be included by the generic API-compatible history filter.
 
 ## Integration points
 
@@ -160,13 +189,14 @@ Checklist for all plans. Plan layout and implementation workflow:
   - Leave non-Just Ask agents on their current history behaviour.
 - 🔷 ⏳ `libollmchat/History/Session.vala`
   - Trigger the background summary after assistant completion.
-  - Persist `conversation_summary`.
+  - Append a `conversation-summary` message after validation succeeds.
   - Keep chat completion UI behaviour independent from summary completion.
 - 🔷 ⏳ `libollmchat/Message.vala`
+  - Add the `conversation-summary` role.
   - Add only the minimum metadata needed for stable references.
   - Reuse existing `tool_calls`, `tool_call_id`, and `name` fields.
 - 🔷 ⏳ `libollmchat/History/SessionJson.vala`
-  - Load the persisted summary for restored sessions.
+  - Load `conversation-summary` messages with the normal `messages` array.
 - 💩 ⏳ `resources/chat-prompts/summary_history.md`
   - Add the summarizer prompt template.
 - 💩 ⏳ `libollmchat/Tool/History.vala`
@@ -174,23 +204,25 @@ Checklist for all plans. Plan layout and implementation workflow:
 
 ## Phase tasks
 
-- 🔷 ⏳ Phase 1: session summary metadata.
-  - Add the session property.
-  - Save and load it through JSON.
-  - Keep old sessions valid when the field is absent.
+- 🔷 ⏳ Phase 1: transcript summary message.
+  - Add the `conversation-summary` role.
+  - Save and load it through the existing JSON `messages` array.
+  - Keep old sessions valid when no summary message exists.
 - 🔷 ⏳ Phase 2: reference rendering.
   - Build a small formatter that emits referenced turn packets from
     `session.messages`.
-  - Include user, agent, and tool reference labels.
+  - Include user, agent, and tool reference labels as markdown links.
 - 🔷 ⏳ Phase 3: background summarizer.
   - Run after Just Ask completion.
   - Do not block the completed assistant response.
-  - Store and display the new summary.
+  - Validate markdown links before storing.
+  - Store and display the new summary message.
 - 🔷 ⏳ Phase 4: summarized main requests.
   - Send system plus latest user for Just Ask when a summary exists.
   - Include history-tool instructions in the system message.
 - 🔷 ⏳ Phase 5: history recall tool.
-  - Resolve `#user-N`, `#agent-N`, and `#tool-N` against the current session.
+  - Resolve `[#user-N](#user-N)`, `[#agent-N](#agent-N)`, and
+    `[#tool-N](#tool-N)` against the current session.
   - Return exact message content and useful metadata.
 - 💩 ⏳ Phase 6: polish.
   - Add a collapsed UI treatment for the summary output.
@@ -201,26 +233,112 @@ Checklist for all plans. Plan layout and implementation workflow:
 - 🔷 ⏳ First-turn manual check:
   - Send one Just Ask prompt.
   - Confirm the assistant response completes before the summary appears.
-  - Confirm the session JSON contains `conversation_summary`.
+  - Confirm the session JSON contains a `conversation-summary` message.
 - 🔷 ⏳ Follow-up request check:
   - Send a second prompt.
   - Confirm the main request body contains only system plus latest user.
   - Confirm the system message includes the prior summary.
 - 🔷 ⏳ Reference check:
-  - Confirm summaries contain `#user-N` and `#agent-N` references.
+  - Confirm summaries contain markdown links such as `[#user-N](#user-N)` and
+    `[#agent-N](#agent-N)`.
   - Run a prompt that needs prior exact text.
   - Confirm the model can call the history tool with a reference and receive
     the stored content.
+- 🔷 ⏳ Validation check:
+  - Make the summarizer return a link that was not provided.
+  - Confirm the summary is rejected or retried.
+  - Make the summarizer return a bare `#user-N` reference.
+  - Confirm the summary is rejected or retried.
 - 🔷 ⏳ Tool-call check:
   - Use a prompt that triggers a tool.
-  - Confirm tool call or tool result references are emitted as `#tool-N`.
+  - Confirm tool call or tool result references are emitted as
+    `[#tool-N](#tool-N)`.
   - Confirm the history tool can recall them.
 - 💩 ⏳ Regression check:
-  - Restore an older session without `conversation_summary`.
+  - Restore an older session without a `conversation-summary` message.
   - Confirm it loads and falls back to current full-history behaviour until the
     next completed turn.
 
 ## Concrete code proposals
+
+### 1. `resources/chat-prompts/summary_history.md` - draft summarizer system prompt
+
+**Why:** The summarizer needs explicit instructions for markdown-link references,
+the 250-word limit, and validation-friendly output.
+
+**Where:** New prompt resource used by the background Just Ask summary call.
+
+**Depends on:** Phase 2 reference rendering.
+
+#### Add
+
+```markdown
+You summarize an OLLMchat Just Ask conversation for future turns.
+
+Your output will be stored as a conversation-summary transcript message.
+The next assistant call will receive this summary instead of the full prior
+transcript.
+
+Write one concise summary under 250 words.
+
+Use markdown links when referring to prior messages or tools.
+Only use links that appear in the Allowed references section of the user
+message.
+Do not write bare references like #user-1.
+Write [#user-1](#user-1), [#agent-2](#agent-2), or [#tool-6](#tool-6).
+
+Preserve user intent, decisions, constraints, unresolved questions, and facts
+needed for a follow-up.
+Omit greetings, filler, raw tool output, and implementation details that are
+not useful for the next turn.
+
+Output only the summary text.
+
+---
+
+## Previous summary
+
+{previous_summary}
+
+## New turn
+
+{turn_references}
+
+## Allowed references
+
+{allowed_references}
+```
+
+### 2. `resources/chat-prompts/just_ask_summary_system.md` - draft main system prompt
+
+**Why:** Follow-up Just Ask requests need a system message that carries the
+latest transcript-stored summary and explains history recall links.
+
+**Where:** New prompt resource used when `Agent.Base.send_async()` builds a
+summarized Just Ask request.
+
+**Depends on:** Phase 4 summarized main requests and Phase 5 history recall
+tool.
+
+#### Add
+
+```markdown
+You are the Just Ask agent.
+
+The conversation history below is a concise summary, not the full transcript.
+Markdown links such as [#user-1](#user-1), [#agent-2](#agent-2), and
+[#tool-6](#tool-6) refer to exact stored messages in the current session.
+
+If you need exact wording, a full prior assistant response, or tool output,
+call the history tool with the relevant markdown link.
+Do not assume the summary contains every detail from the referenced message.
+
+## Conversation history summary
+
+{conversation_summary}
+```
+
+### 3. Remaining implementation hunks
 
 - ⏳ Deferred until this draft is reviewed.
   - The implementation should add mechanical `Remove` / `Replace with` /
@@ -232,6 +350,8 @@ Checklist for all plans. Plan layout and implementation workflow:
 ## LLM notes
 
 - 🚫 Do not convert this into a general memory system in the first pass.
+- 🚫 Do not store the active summary only as top-level session metadata.
+  - The summary belongs in the standard transcript JSON as a message.
 - 🚫 Do not delete or stop persisting the full transcript.
   - The history recall tool depends on exact stored messages.
 - 🚫 Do not summarize while the assistant is still streaming.

--- a/docs/plans/2.31-just-ask-summary-history.md
+++ b/docs/plans/2.31-just-ask-summary-history.md
@@ -76,6 +76,9 @@ Checklist for all plans. Plan layout and implementation workflow:
   - The summary should cite important prior turns with markdown links like
     `[#user-N](#user-N)`, `[#agent-N](#agent-N)`, and
     `[#tool-N](#tool-N)`.
+  - As the conversation grows, the summarizer may drop older references that
+    are no longer useful for likely follow-up turns.
+  - The summary should not become a catalogue of historical links.
   - The summary should not quote long source text or tool output.
   - If exact details are needed, the model should call the history recall tool.
 
@@ -125,6 +128,7 @@ Checklist for all plans. Plan layout and implementation workflow:
     response, and any tool references.
   - It must produce a concise summary under 250 words.
   - It should cite source turns using only the provided markdown links.
+  - It may drop older references once the summary is getting crowded.
   - It should preserve unresolved user intent, decisions, preferences, and
     important facts.
   - It should omit filler, greetings, and raw tool output.
@@ -249,6 +253,10 @@ Checklist for all plans. Plan layout and implementation workflow:
   - Confirm the summary is rejected or retried.
   - Make the summarizer return a bare `#user-N` reference.
   - Confirm the summary is rejected or retried.
+- 🔷 ⏳ Reference pruning check:
+  - Run enough turns that the summary would be crowded if it retained every
+    prior reference.
+  - Confirm the summarizer can omit older links while keeping the summary useful.
 - 🔷 ⏳ Tool-call check:
   - Use a prompt that triggers a tool.
   - Confirm tool call or tool result references are emitted as
@@ -289,6 +297,9 @@ Write [#user-1](#user-1), [#agent-2](#agent-2), or [#tool-6](#tool-6).
 
 Preserve user intent, decisions, constraints, unresolved questions, and facts
 needed for a follow-up.
+As the conversation grows, drop old references that are no longer useful.
+Do not keep links just to preserve a complete citation trail.
+The summary should not become a catalogue of historical links.
 Omit greetings, filler, raw tool output, and implementation details that are
 not useful for the next turn.
 

--- a/docs/plans/2.31-just-ask-summary-history.md
+++ b/docs/plans/2.31-just-ask-summary-history.md
@@ -1,0 +1,238 @@
+# 2.31. Just Ask summarized history and recall links
+
+Status: ⏳ proposed
+
+ℹ️ Coding standards checklist: `.cursor/rules/CODING_STANDARDS.md` —
+Checklist for all plans. Plan layout and implementation workflow:
+`docs/guide-to-writing-plans.md`.
+
+## Purpose
+
+- 🔷 ⏳ Add a Just Ask enhancement where a completed chat turn is followed by a
+  background summarization request.
+  - The user-visible assistant reply should finish normally first.
+  - The UI should be free to react to completion before the summary call runs.
+- 🔷 ⏳ Store an under-250-word concise summary of the conversation.
+  - The summary should be updated after each completed Just Ask turn.
+  - The summary becomes the compact history sent to the model on later turns.
+- 🔷 ⏳ Use hash-style references inside the summary.
+  - User messages should be referable as `#user-N`.
+  - Assistant responses should be referable as `#agent-N`.
+  - Tool calls or tool results should be referable as `#tool-N` when available.
+  - The numbers are stable message/session references, not per-role sequential
+    counters.
+- 🔷 ⏳ On follow-up turns, send only a system message plus the latest user
+  message to the model.
+  - The system message includes the stored conversation summary.
+  - The system message explains that more detail is available through a history
+    recall tool.
+- 🔷 ⏳ Provide a history tool that can recall a specific referenced request,
+  response, or tool event by hash link.
+- 🔷 ⏳ Display the latest summary in the standard chat UI as a collapsed or
+  summary-style output.
+
+## Current behaviour
+
+- ℹ️ `History.Session.send()` stores a user turn as `user-sent` plus a visible
+  `ui` frame, then calls `Agent.Base.send_async()` with a `user` message.
+- ℹ️ `Agent.Base.send_async()` appends the current `user` message to
+  `session.messages`, then sends every prior API-compatible `user`,
+  `assistant`, and `tool` message to the model.
+- ℹ️ Streaming assistant content is stored as `content-stream` messages.
+  Tool-call assistant messages are stored as `assistant` messages with
+  `Message.tool_calls`.
+- ℹ️ Tool replies are stored as `tool` messages with `tool_call_id` and `name`.
+- ℹ️ Session JSON currently persists top-level metadata and the full
+  `messages` array. There is no top-level conversation summary field.
+
+## Proposed behaviour
+
+- 🔷 ⏳ First Just Ask turn:
+  - Send the latest user request normally.
+  - After the assistant response is complete, start a non-streaming
+    summarizer chat in the background.
+  - The summarizer receives:
+    - the user request with its `#user-N` reference.
+    - the assistant response with its `#agent-N` reference.
+    - any tool references from that turn.
+  - The summarizer returns a concise summary under 250 words.
+  - Persist the summary and show it in the UI as the collapsed summary output.
+- 🔷 ⏳ Later Just Ask turns:
+  - Build the main request as:
+    - a system message containing the stored summary and history-tool
+      instructions.
+    - the latest user message.
+  - Do not send the full prior transcript to the main chat request.
+  - After completion, send the summarizer:
+    - the previous summary.
+    - the latest user request with `#user-N`.
+    - the latest assistant response with `#agent-N`.
+    - any new `#tool-N` references.
+  - Replace the stored summary with the summarizer output.
+- 🔷 ⏳ Summary references should stay useful to the model.
+  - The summary should cite important prior turns with `#user-N`,
+    `#agent-N`, and `#tool-N`.
+  - The summary should not quote long source text or tool output.
+  - If exact details are needed, the model should call the history recall tool.
+
+## Reference model
+
+- 🔷 ⏳ Use the existing persisted `session.messages` ordering as the source of
+  reference numbers.
+  - `#user-N` points at a persisted `user-sent` or API `user` message.
+  - `#agent-N` points at persisted assistant-visible content for a turn.
+  - `#tool-N` points at persisted `assistant` tool-call messages or `tool`
+    reply messages.
+- 💩 ⏳ Prefer message-array indexes for `N` in the first implementation.
+  - This matches the user's note that numbers are session references rather
+    than sequential per role.
+  - It avoids adding a message database table in this plan.
+- 💩 ⏳ Add an explicit persisted `history_ref` on `Message` only if array
+  indexes prove unstable during restore, deletion, or migration.
+
+## Summary prompt contract
+
+- 🔷 ⏳ The summarizer prompt should say:
+  - It receives the previous summary, the latest user request, the assistant
+    response, and any tool references.
+  - It must produce a concise summary under 250 words.
+  - It should cite source turns using the provided hash references.
+  - It should preserve unresolved user intent, decisions, preferences, and
+    important facts.
+  - It should omit filler, greetings, and raw tool output.
+- 💩 ⏳ Use a dedicated prompt resource under `resources/chat-prompts/`.
+  - The existing prompt-template resource pattern used by `2.30` is a good
+    fit.
+- 💩 ⏳ Run the summarizer with tools disabled and streaming off.
+  - Use the session model initially.
+  - Add a config override later only if review asks for a cheaper or faster
+    summary model.
+
+## Main request system message
+
+- 🔷 ⏳ For summarized Just Ask follow-ups, the system message should include:
+  - the normal Just Ask identity or neutral assistant instruction.
+  - a heading that says the conversation history is summarized.
+  - the latest stored summary.
+  - instructions to call the history recall tool when a referenced turn is
+    needed verbatim.
+- 🔷 ⏳ The latest user request stays the only `user` message in the request.
+- 💩 ⏳ Keep full-history mode as the fallback only when no summary exists.
+  - First turn has no summary.
+  - Sessions loaded from older JSON have no summary until a turn completes.
+
+## History recall tool
+
+- 🔷 ⏳ Add a tool that accepts one or more hash references.
+  - Examples: `#user-1`, `#agent-2`, `#tool-6`.
+  - It returns the exact stored message excerpts for those references.
+- 🔷 ⏳ The tool should work against the current session only.
+  - It must not search other sessions.
+  - It should return a clear not-found result for unknown references.
+- 💩 ⏳ Name the tool `history`.
+  - This matches the user's wording: “use the history tool”.
+  - The tool description should explain the hash-reference syntax.
+- 💩 ⏳ Register the tool only for Just Ask summary mode.
+  - It can live in `libollmchat/Tool/History.vala` if kept generic.
+  - It can live under a Just Ask agent helper if review prefers narrower
+    ownership.
+
+## Session persistence and UI
+
+- 🔷 ⏳ Persist the current summary on the session.
+  - Add a top-level session property such as `conversation_summary`.
+  - Serialize it in `History.Session.serialize_property()`.
+  - Load it through `History.SessionJson`.
+- 🔷 ⏳ Display the latest summary as a collapsed summary output in the standard
+  chat UI.
+- 💩 ⏳ Store only the latest summary as metadata.
+  - The visible UI summary message can be regenerated from metadata on restore.
+  - This avoids duplicating each summary revision in `messages`.
+- 💩 ⏳ If the UI cannot render a metadata summary without larger changes, add a
+  `ui` message for the summary as a short-term bridge.
+  - Mark it with a distinct fenced header or class so it can be collapsed later.
+
+## Integration points
+
+- 🔷 ⏳ `libollmchat/Agent/Base.vala`
+  - Change Just Ask request assembly so summary mode can send system plus
+    latest user only.
+  - Leave non-Just Ask agents on their current history behaviour.
+- 🔷 ⏳ `libollmchat/History/Session.vala`
+  - Trigger the background summary after assistant completion.
+  - Persist `conversation_summary`.
+  - Keep chat completion UI behaviour independent from summary completion.
+- 🔷 ⏳ `libollmchat/Message.vala`
+  - Add only the minimum metadata needed for stable references.
+  - Reuse existing `tool_calls`, `tool_call_id`, and `name` fields.
+- 🔷 ⏳ `libollmchat/History/SessionJson.vala`
+  - Load the persisted summary for restored sessions.
+- 💩 ⏳ `resources/chat-prompts/summary_history.md`
+  - Add the summarizer prompt template.
+- 💩 ⏳ `libollmchat/Tool/History.vala`
+  - Add the recall tool if review accepts the generic tool location.
+
+## Phase tasks
+
+- 🔷 ⏳ Phase 1: session summary metadata.
+  - Add the session property.
+  - Save and load it through JSON.
+  - Keep old sessions valid when the field is absent.
+- 🔷 ⏳ Phase 2: reference rendering.
+  - Build a small formatter that emits referenced turn packets from
+    `session.messages`.
+  - Include user, agent, and tool reference labels.
+- 🔷 ⏳ Phase 3: background summarizer.
+  - Run after Just Ask completion.
+  - Do not block the completed assistant response.
+  - Store and display the new summary.
+- 🔷 ⏳ Phase 4: summarized main requests.
+  - Send system plus latest user for Just Ask when a summary exists.
+  - Include history-tool instructions in the system message.
+- 🔷 ⏳ Phase 5: history recall tool.
+  - Resolve `#user-N`, `#agent-N`, and `#tool-N` against the current session.
+  - Return exact message content and useful metadata.
+- 💩 ⏳ Phase 6: polish.
+  - Add a collapsed UI treatment for the summary output.
+  - Add debug logging around summary refresh boundaries.
+
+## Verification
+
+- 🔷 ⏳ First-turn manual check:
+  - Send one Just Ask prompt.
+  - Confirm the assistant response completes before the summary appears.
+  - Confirm the session JSON contains `conversation_summary`.
+- 🔷 ⏳ Follow-up request check:
+  - Send a second prompt.
+  - Confirm the main request body contains only system plus latest user.
+  - Confirm the system message includes the prior summary.
+- 🔷 ⏳ Reference check:
+  - Confirm summaries contain `#user-N` and `#agent-N` references.
+  - Run a prompt that needs prior exact text.
+  - Confirm the model can call the history tool with a reference and receive
+    the stored content.
+- 🔷 ⏳ Tool-call check:
+  - Use a prompt that triggers a tool.
+  - Confirm tool call or tool result references are emitted as `#tool-N`.
+  - Confirm the history tool can recall them.
+- 💩 ⏳ Regression check:
+  - Restore an older session without `conversation_summary`.
+  - Confirm it loads and falls back to current full-history behaviour until the
+    next completed turn.
+
+## Concrete code proposals
+
+- ⏳ Deferred until this draft is reviewed.
+  - The implementation should add mechanical `Remove` / `Replace with` /
+    `Add` fences for the files listed in `## Integration points`.
+  - Keep the first implementation limited to Just Ask.
+  - Do not change Code Assistant, skill-runner, or child-agent history flows
+    unless review explicitly expands the plan.
+
+## LLM notes
+
+- 🚫 Do not convert this into a general memory system in the first pass.
+- 🚫 Do not delete or stop persisting the full transcript.
+  - The history recall tool depends on exact stored messages.
+- 🚫 Do not summarize while the assistant is still streaming.
+  - The summary must reflect the completed response.

--- a/docs/plans/2.31-just-ask-summary-history.md
+++ b/docs/plans/2.31-just-ask-summary-history.md
@@ -32,6 +32,9 @@ Checklist for all plans. Plan layout and implementation workflow:
   response, or tool event by markdown hash link.
 - 🔷 ⏳ Display the latest summary in the standard chat UI as a collapsed or
   summary-style output.
+  - While the summary call is running, show the standard dotted waiting message
+    with text like `summarizing conversation`.
+  - Stream summary text into a collapsed summary frame as chunks arrive.
 
 ## Current behaviour
 
@@ -51,8 +54,9 @@ Checklist for all plans. Plan layout and implementation workflow:
 
 - 🔷 ⏳ First Just Ask turn:
   - Send the latest user request normally.
-  - After the assistant response is complete, start a non-streaming
-    summarizer chat in the background.
+  - After the assistant response is complete, start a streaming summarizer chat
+    in the background.
+  - Disable thinking for the summarizer call so only summary text streams back.
   - The summarizer receives:
     - the user request with its `[#user-N](#user-N)` reference.
     - the assistant response with its `[#agent-N](#agent-N)` reference.
@@ -72,6 +76,11 @@ Checklist for all plans. Plan layout and implementation workflow:
     - the latest assistant response with `[#agent-N](#agent-N)`.
     - any new `[#tool-N](#tool-N)` references.
   - Append the new summary as the latest summary transcript message.
+- 🔷 ⏳ Summary-call UI should reuse the standard session-message pattern.
+  - Add a `ui-waiting` message with a short label such as
+    `summarizing conversation`.
+  - Stream returned text into the visible `conversation-summary` message.
+  - Render it collapsed with a summary-specific color or frame class.
 - 🔷 ⏳ Summary references should stay useful to the model.
   - The summary should cite important prior turns with markdown links like
     `[#user-N](#user-N)`, `[#agent-N](#agent-N)`, and
@@ -135,10 +144,29 @@ Checklist for all plans. Plan layout and implementation workflow:
 - 💩 ⏳ Use a dedicated prompt resource under `resources/chat-prompts/`.
   - The existing prompt-template resource pattern used by `2.30` is a good
     fit.
-- 💩 ⏳ Run the summarizer with tools disabled and streaming off.
+- 🔷 ⏳ Run the summarizer with tools disabled and thinking disabled.
+- 🔷 ⏳ Run the summarizer with streaming enabled.
+  - Stream text into the collapsed summary message as it arrives.
   - Use the session model initially.
   - Add a config override later only if review asks for a cheaper or faster
     summary model.
+
+## Summary-call UI
+
+- 🔷 ⏳ Use existing session message APIs to show summarization progress.
+  - Emit `ui-waiting` while the request is in flight.
+  - Use a label like `summarizing conversation`.
+  - Clear or naturally replace the waiting indicator when summary content starts.
+- 🔷 ⏳ Stream summary chunks into a collapsed `conversation-summary` message.
+  - The message is visible in the chat UI.
+  - The message is stored in the standard session JSON transcript after the
+    summary validates.
+  - If validation fails, replace the draft summary with a warning or keep the
+    previous valid summary as active.
+- 💩 ⏳ Use a summary-specific frame class such as
+  `markdown.oc-frame-summary.collapsed`.
+  - Existing precedent uses classes like `markdown.oc-frame-info.collapsed`.
+  - The exact color class can be picked during implementation.
 
 ## Main request system message
 
@@ -184,6 +212,8 @@ Checklist for all plans. Plan layout and implementation workflow:
 - 💩 ⏳ Mark `conversation-summary` as UI-visible and API-hidden.
   - It should be visible through the collapsed summary UI.
   - It should not be included by the generic API-compatible history filter.
+  - Streaming summary chunks should update this message rather than create
+    normal assistant `content-stream` history.
 
 ## Integration points
 
@@ -194,6 +224,7 @@ Checklist for all plans. Plan layout and implementation workflow:
 - 🔷 ⏳ `libollmchat/History/Session.vala`
   - Trigger the background summary after assistant completion.
   - Append a `conversation-summary` message after validation succeeds.
+  - Emit the `ui-waiting` summarization status before the summary request.
   - Keep chat completion UI behaviour independent from summary completion.
 - 🔷 ⏳ `libollmchat/Message.vala`
   - Add the `conversation-summary` role.
@@ -219,6 +250,8 @@ Checklist for all plans. Plan layout and implementation workflow:
 - 🔷 ⏳ Phase 3: background summarizer.
   - Run after Just Ask completion.
   - Do not block the completed assistant response.
+  - Set `think = false` for the summary chat call.
+  - Stream summary output into the collapsed summary message.
   - Validate markdown links before storing.
   - Store and display the new summary message.
 - 🔷 ⏳ Phase 4: summarized main requests.
@@ -237,7 +270,12 @@ Checklist for all plans. Plan layout and implementation workflow:
 - 🔷 ⏳ First-turn manual check:
   - Send one Just Ask prompt.
   - Confirm the assistant response completes before the summary appears.
+  - Confirm a dotted `summarizing conversation` waiting message appears.
+  - Confirm the summary text streams into a collapsed summary frame.
   - Confirm the session JSON contains a `conversation-summary` message.
+- 🔷 ⏳ Thinking check:
+  - Use a model that can emit thinking.
+  - Confirm the summary call disables thinking and streams only summary text.
 - 🔷 ⏳ Follow-up request check:
   - Send a second prompt.
   - Confirm the main request body contains only system plus latest user.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a proposed 2.31 plan for Just Ask summarized session history.
- Specify storing summaries as `conversation-summary` messages in the standard session JSON transcript.
- Cover background post-response summarization, markdown hash links, link validation, reference pruning as history grows, compact follow-up requests, and a history recall tool.
- Specify summary calls stream into a collapsed summary frame with thinking disabled and standard `ui-waiting` progress messaging.
- Include draft prompt blocks for the background summarizer and summarized Just Ask system message.

## Testing
- Docs-only change.
- Ran `git diff --check` and `git diff --cached --check` before commits.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41f0a978-8fd8-4ce3-868b-a25ec690d474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41f0a978-8fd8-4ce3-868b-a25ec690d474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

